### PR TITLE
Add support to specify HTTP client transport with request config (#1)

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -3,6 +3,7 @@ package chargebee
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"time"
 )
 
@@ -11,6 +12,7 @@ type Environment struct {
 	SiteName        string
 	ChargebeeDomain string
 	Protocol        string
+	HTTPClient      *http.Client
 }
 
 var (

--- a/environment.go
+++ b/environment.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/cenkalti/backoff"
 )
 
 type Environment struct {
@@ -13,6 +15,7 @@ type Environment struct {
 	ChargebeeDomain string
 	Protocol        string
 	HTTPClient      *http.Client
+	BackoffConfig   backoff.BackOff
 }
 
 var (
@@ -33,6 +36,7 @@ func Configure(key string, siteName string) {
 	}
 	DefaultEnv = Environment{Key: key, SiteName: siteName}
 }
+
 func (env *Environment) apiBaseUrl() string {
 	if env.Protocol == "" {
 		env.Protocol = "https"

--- a/http_request.go
+++ b/http_request.go
@@ -10,8 +10,12 @@ import (
 var httpClient = &http.Client{Timeout: DefaultHTTPTimeout}
 
 //Do is used to execute an API Request.
-func Do(req *http.Request) (string, error) {
-	response, err := httpClient.Do(req)
+func Do(req *http.Request, env Environment) (string, error) {
+	client := httpClient
+	if env.HTTPClient != nil {
+		client = env.HTTPClient
+	}
+	response, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}

--- a/http_request.go
+++ b/http_request.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 	"io/ioutil"
 	"net/http"
+	"net/url"
+
+	"github.com/cenkalti/backoff"
 )
 
 var httpClient = &http.Client{Timeout: DefaultHTTPTimeout}
@@ -15,10 +18,35 @@ func Do(req *http.Request, env Environment) (string, error) {
 	if env.HTTPClient != nil {
 		client = env.HTTPClient
 	}
-	response, err := client.Do(req)
+
+	backoffConfig := env.BackoffConfig
+	if backoffConfig == nil { // if no backoff configured, use default one
+		backoffConfig = backoff.NewExponentialBackOff()
+	}
+
+	if req.Method != http.MethodGet { // if the request is anything other than GET, don't use backoff
+		backoffConfig = &backoff.StopBackOff{}
+	}
+
+	var response *http.Response
+	var err error
+	// Retry on HTTP 429 rate limit, or network error, see:
+	// https://godoc.org/github.com/cenkalti/backoff#pkg-constants
+	backoff.Retry(func() error {
+		response, err = client.Do(req)
+		if _, ok := err.(*url.Error); ok {
+			return nil
+		}
+		if response == nil || response.StatusCode == http.StatusTooManyRequests {
+			return errors.New("retrying")
+		}
+		return nil
+	}, backoffConfig)
+
 	if err != nil {
 		return "", err
 	}
+
 	defer response.Body.Close()
 	resBody, err := ioutil.ReadAll(response.Body)
 	if err != nil {
@@ -29,6 +57,7 @@ func Do(req *http.Request, env Environment) (string, error) {
 	}
 	return string(resBody), nil
 }
+
 func ErrorHandling(resBody []byte) error {
 	cbErr := &Error{}
 	err := json.Unmarshal(resBody, cbErr)

--- a/list_request.go
+++ b/list_request.go
@@ -10,7 +10,7 @@ func (request RequestObj) ListRequestWithEnv(env Environment) (*ResultList, erro
 	if err != nil {
 		panic(err)
 	}
-	res, err1 := Do(req)
+	res, err1 := Do(req, env)
 	result := &ResultList{}
 	if err1 != nil {
 		return result, err1

--- a/request.go
+++ b/request.go
@@ -17,7 +17,7 @@ func (request RequestObj) RequestWithEnv(env Environment) (*Result, error) {
 	if err != nil {
 		panic(err)
 	}
-	res, err1 := Do(req)
+	res, err1 := Do(req, env)
 	result := &Result{}
 	if err1 != nil {
 		return result, err1


### PR DESCRIPTION
This is necessary in case you need to record with VCR cassettes to make proper integration tests. We're using this fork in our code and would be glad if this can be merged. We tried to do it in the most backwards-compatible way possible.