### PR TITLE
include response body for unmarshal errors

### DIFF
--- a/http_request.go
+++ b/http_request.go
@@ -3,15 +3,16 @@ package chargebee
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 )
 
 var httpClient = &http.Client{Timeout: TotalHTTPTimeout}
 
-//Do is used to execute an API Request.
+// Do is used to execute an API Request.
 func Do(req *http.Request) (string, error) {
-    httpClient = &http.Client{Timeout: TotalHTTPTimeout}
+	httpClient = &http.Client{Timeout: TotalHTTPTimeout}
 	response, err := httpClient.Do(req)
 	if err != nil {
 		return "", err
@@ -26,18 +27,18 @@ func Do(req *http.Request) (string, error) {
 	}
 	return string(resBody), nil
 }
+
 func ErrorHandling(resBody []byte) error {
 	cbErr := &Error{}
 	err := json.Unmarshal(resBody, cbErr)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to unmarshal response body: %w (body=%q)", err, string(resBody))
 	}
 	if cbErr.APIErrorCode == "" {
 		return errors.New("the api_error_code is not present - probably not a chargebee error")
 
 	}
 	switch cbErr.Type {
-
 	case PaymentError:
 		cbErr.Err = &paymentErr{cbErr: cbErr}
 	case InvalidRequestError:


### PR DESCRIPTION
Should server be down a non-JSON response body is received and JSON unmarshal error is returned without any context hiding the root cause. An example error could look like this:
```
invalid character '<' looking for beginning of value
```

It is useful to see the response body in this situations as it may contain useful data.