### PR TITLE
Use existing httpClient when sending requests

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -14,16 +14,18 @@ type Environment struct {
 	Protocol        string
 }
 
+const (
+	APIVersion         = "v2"
+	Charset            = "UTF-8"
+	DefaultHTTPTimeout = 80 * time.Second
+)
+
 var (
-	TotalHTTPTimeout    = 80 * time.Second
+	TotalHTTPTimeout      = DefaultHTTPTimeout
 	ExportWaitInSecs      = 3 * time.Second
 	TimeMachineWaitInSecs = 3 * time.Second
 	DefaultEnv            Environment
-)
-
-const (
-	APIVersion = "v2"
-	Charset    = "UTF-8"
+	httpClient            *http.Client
 )
 
 func Configure(key string, siteName string) {
@@ -32,9 +34,7 @@ func Configure(key string, siteName string) {
 	}
 	DefaultEnv = Environment{Key: key, SiteName: siteName}
 }
-func WithHTTPClient(c *http.Client) {
-	httpClient = c
-}
+
 func (env *Environment) apiBaseUrl() string {
 	if env.Protocol == "" {
 		env.Protocol = "https"
@@ -52,6 +52,20 @@ func DefaultConfig() Environment {
 	return DefaultEnv
 }
 
+func NewDefaultHTTPClient() *http.Client {
+	return &http.Client{Timeout: TotalHTTPTimeout}
+}
+
+func WithHTTPClient(c *http.Client) {
+	if c.Timeout == 0 {
+		c.Timeout = TotalHTTPTimeout
+	}
+	httpClient = c
+}
+
 func UpdateTotalHTTPTimeout(timeout time.Duration) {
 	TotalHTTPTimeout = timeout
+	if httpClient != nil {
+		httpClient.Timeout = TotalHTTPTimeout
+	}
 }

--- a/http_request.go
+++ b/http_request.go
@@ -7,11 +7,11 @@ import (
 	"net/http"
 )
 
-var httpClient = &http.Client{Timeout: TotalHTTPTimeout}
-
 //Do is used to execute an API Request.
 func Do(req *http.Request) (string, error) {
-    httpClient = &http.Client{Timeout: TotalHTTPTimeout}
+	if httpClient == nil {
+		httpClient = NewDefaultHTTPClient()
+	}
 	response, err := httpClient.Do(req)
 	if err != nil {
 		return "", err

--- a/tests/environment_test.go
+++ b/tests/environment_test.go
@@ -1,7 +1,9 @@
 package tests
 
 import (
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/chargebee/chargebee-go"
 	"github.com/stretchr/testify/assert"
@@ -12,4 +14,31 @@ func TestEnv(t *testing.T) {
 	defaultEnv := chargebee.DefaultConfig()
 	assert.Equal(t, defaultEnv.SiteName, "Your site Name")
 	assert.Equal(t, defaultEnv.Key, "Your site Key")
+}
+
+func TestDefaultHTTPClient(t *testing.T) {
+	c := chargebee.NewDefaultHTTPClient()
+	chargebee.WithHTTPClient(c)
+	assert.Equal(t, chargebee.DefaultHTTPTimeout, c.Timeout)
+
+	// UpdateTotalHTTPTimeout should set the timeout
+	// on new and the existing http.Clients
+	// as TotalHTTPTimeout is only read on http.Client creation
+	timeout := 3 * time.Second
+	chargebee.UpdateTotalHTTPTimeout(timeout)
+	c2 := chargebee.NewDefaultHTTPClient()
+	assert.Equal(t, timeout, c2.Timeout)
+	assert.Equal(t, c2.Timeout, c.Timeout)
+
+	// http.Client should always have a timeout
+	c3 := &http.Client{}
+	chargebee.WithHTTPClient(c3)
+	assert.Equal(t, timeout, c3.Timeout)
+
+	// respect the timeout passed in?
+	timeout2 := 5 * time.Second
+	c4 := &http.Client{Timeout: timeout2}
+	chargebee.WithHTTPClient(c4)
+	assert.Equal(t, timeout2, c4.Timeout)
+	assert.NotEqual(t, timeout, c4.Timeout)
 }


### PR DESCRIPTION
Currently, a new http.Client is created on every request. This pull request alters chargebee.Do() to use the existing httpClient or create a new default http.Client if it is nil. Added NewDefaultHTTPClient() function to standardize creation. Initialization is lazy, but could just as easily create a default client from the outset. Also moved httpClient into environment.go where the functions that set and change it are.  

Since TotalHTTPTimeout is only read on client creation, UpdateTotalHTTPTimeout should update httpClient, if it exists. TotalHTTPTimeout should probably be unexported, since changing it directly has no impact on existing clients - don't imagine that's the expected behaviour...but I didn't want to mess w/ the existing API.

Also updated WithHTTPClient to set httpClient.Timeout to TotalHTTPTimeout if passed in client does not have a timeout set.

