### PR TITLE
Add support for request scoped contexts

### DIFF
--- a/http_util.go
+++ b/http_util.go
@@ -1,6 +1,7 @@
 package chargebee
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -65,12 +66,12 @@ func (request RequestObj) Headers(key string, value string) RequestObj {
 	request.Header[key] = value
 	return request
 }
-func newRequest(env Environment, method string, path string, body io.Reader, headers map[string]string) (*http.Request, error) {
+func newRequest(ctx context.Context, env Environment, method string, path string, body io.Reader, headers map[string]string) (*http.Request, error) {
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
 	path = env.apiBaseUrl() + path
-	httpReq, err := http.NewRequest(method, path, body)
+	httpReq, err := http.NewRequestWithContext(ctx, method, path, body)
 	if err != nil {
 		panic(err)
 	}

--- a/list_request.go
+++ b/list_request.go
@@ -1,12 +1,19 @@
 package chargebee
 
+import "context"
+
 func (request RequestObj) ListRequest() (*ResultList, error) {
-	result, err := request.ListRequestWithEnv(DefaultConfig())
-	return result, err
+	return request.ListRequestWithContext(context.Background())
+}
+func (request RequestObj) ListRequestWithContext(ctx context.Context) (*ResultList, error) {
+	return request.ListRequestWithContextWithEnv(ctx, DefaultConfig())
 }
 func (request RequestObj) ListRequestWithEnv(env Environment) (*ResultList, error) {
+	return request.ListRequestWithContextWithEnv(context.Background(), env)
+}
+func (request RequestObj) ListRequestWithContextWithEnv(ctx context.Context, env Environment) (*ResultList, error) {
 	path, body := getBody(request.Method, request.Path, request.Params)
-	req, err := newRequest(env, request.Method, path, body, request.Header)
+	req, err := newRequest(ctx, env, request.Method, path, body, request.Header)
 	if err != nil {
 		panic(err)
 	}

--- a/request.go
+++ b/request.go
@@ -2,18 +2,24 @@ package chargebee
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net/url"
 	"strings"
 )
 
 func (request RequestObj) Request() (*Result, error) {
-	result, err := request.RequestWithEnv(DefaultConfig())
-	return result, err
+	return request.RequestWithContext(context.Background())
+}
+func (request RequestObj) RequestWithContext(ctx context.Context) (*Result, error) {
+	return request.RequestWithContextWithEnv(ctx, DefaultConfig())
 }
 func (request RequestObj) RequestWithEnv(env Environment) (*Result, error) {
+	return request.RequestWithContextWithEnv(context.Background(), env)
+}
+func (request RequestObj) RequestWithContextWithEnv(ctx context.Context, env Environment) (*Result, error) {
 	path, body := getBody(request.Method, request.Path, request.Params)
-	req, err := newRequest(env, request.Method, path, body, request.Header)
+	req, err := newRequest(ctx, env, request.Method, path, body, request.Header)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Adds context support for requests and list requests. Follows same pattern as Go's [http.NewRequest ](https://pkg.go.dev/net/http#NewRequest)and [http.NewRequestWithContext](https://pkg.go.dev/net/http#NewRequestWithContext), using context.Background() as the default context..