### PR TITLE
Change apply_on for remove discount in a subscription

### DIFF
--- a/models/subscription/subscription.go
+++ b/models/subscription/subscription.go
@@ -862,7 +862,7 @@ type UpdateForItemsSubscriptionItemParams struct {
 	ItemType           enum.ItemType       `json:"item_type,omitempty"`
 }
 type UpdateForItemsDiscountParams struct {
-	ApplyOn       enum.ApplyOn       `json:"apply_on"`
+	ApplyOn       *enum.ApplyOn      `json:"apply_on,omitempty"`
 	DurationType  enum.DurationType  `json:"duration_type"`
 	Percentage    *float64           `json:"percentage,omitempty"`
 	Amount        *int32             `json:"amount,omitempty"`


### PR DESCRIPTION
[According to the parameters description here, ]( https://apidocs.chargebee.com/docs/api/subscriptions?prod_cat_ver=2&lang=go#update_subscription_for_items_discounts_apply_on) the `ApplyOn` is required when creating new discount.

And it works as expected when creating new discount with empty `apply_on`.
```json
{
  "message": "discounts[apply_on][0] : cannot be blank",
  "type": "invalid_request",
  "api_error_code": "invalid_request",
  "param": "discounts[apply_on][0]",
  "error_code": "param_should_not_be_blank",
  "error_msg": "cannot be blank",
  "error_param": "discounts[apply_on][0]",
  "http_status_code": 400
}
```

But when I try to delete a discount from subscription.
I always got this message unless I remove the key `apply_on` from the request payload.

```json
{
  "message": "discounts[apply_on][0] : should not be sent when operation type is REMOVE",
  "type": "invalid_request",
  "api_error_code": "invalid_request",
  "param": "discounts[apply_on][0]",
  "error_code": "param_should_not_be_sent",
  "error_msg": "should not be sent when operation type is REMOVE",
  "error_param": "discounts[apply_on][0]",
  "http_status_code": 400
}
```
https://github.com/chargebee/chargebee-go/blob/5db10caf41f2115c308912054405f840313882a4/models/subscription/subscription.go#L864-L865