### PR TITLE
Fix: Retain forward slashes in Chargebee IDs

### DIFF
--- a/actions/addon/addon.go
+++ b/actions/addon/addon.go
@@ -2,29 +2,29 @@ package addon
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/addon"
-	"net/url"
 )
 
 func Create(params *addon.CreateRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/addons"), params)
 }
 func Update(id string, params *addon.UpdateRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/addons/%v", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/addons/%v", chargebee.IDEscape(id)), params)
 }
 func List(params *addon.ListRequestParams) chargebee.RequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/addons"), params)
 }
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/addons/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/addons/%v", chargebee.IDEscape(id)), nil)
 }
 func Delete(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/addons/%v/delete", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/addons/%v/delete", chargebee.IDEscape(id)), nil)
 }
 func Copy(params *addon.CopyRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/addons/copy"), params)
 }
 func Unarchive(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/addons/%v/unarchive", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/addons/%v/unarchive", chargebee.IDEscape(id)), nil)
 }

--- a/actions/attacheditem/attached_item.go
+++ b/actions/attacheditem/attached_item.go
@@ -2,23 +2,23 @@ package attacheditem
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/attacheditem"
-	"net/url"
 )
 
 func Create(id string, params *attacheditem.CreateRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/items/%v/attached_items", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/items/%v/attached_items", chargebee.IDEscape(id)), params)
 }
 func Update(id string, params *attacheditem.UpdateRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/attached_items/%v", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/attached_items/%v", chargebee.IDEscape(id)), params)
 }
 func Retrieve(id string, params *attacheditem.RetrieveRequestParams) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/attached_items/%v", url.PathEscape(id)), params)
+	return chargebee.Send("GET", fmt.Sprintf("/attached_items/%v", chargebee.IDEscape(id)), params)
 }
 func Delete(id string, params *attacheditem.DeleteRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/attached_items/%v/delete", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/attached_items/%v/delete", chargebee.IDEscape(id)), params)
 }
 func List(id string, params *attacheditem.ListRequestParams) chargebee.RequestObj {
-	return chargebee.SendList("GET", fmt.Sprintf("/items/%v/attached_items", url.PathEscape(id)), params)
+	return chargebee.SendList("GET", fmt.Sprintf("/items/%v/attached_items", chargebee.IDEscape(id)), params)
 }

--- a/actions/card/card.go
+++ b/actions/card/card.go
@@ -2,23 +2,23 @@ package card
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/card"
-	"net/url"
 )
 
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/cards/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/cards/%v", chargebee.IDEscape(id)), nil)
 }
 func UpdateCardForCustomer(id string, params *card.UpdateCardForCustomerRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/credit_card", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/credit_card", chargebee.IDEscape(id)), params)
 }
 func SwitchGatewayForCustomer(id string, params *card.SwitchGatewayForCustomerRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/switch_gateway", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/switch_gateway", chargebee.IDEscape(id)), params)
 }
 func CopyCardForCustomer(id string, params *card.CopyCardForCustomerRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/copy_card", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/copy_card", chargebee.IDEscape(id)), params)
 }
 func DeleteCardForCustomer(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/delete_card", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/delete_card", chargebee.IDEscape(id)), nil)
 }

--- a/actions/comment/comment.go
+++ b/actions/comment/comment.go
@@ -2,20 +2,20 @@ package comment
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/comment"
-	"net/url"
 )
 
 func Create(params *comment.CreateRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/comments"), params)
 }
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/comments/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/comments/%v", chargebee.IDEscape(id)), nil)
 }
 func List(params *comment.ListRequestParams) chargebee.RequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/comments"), params)
 }
 func Delete(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/comments/%v/delete", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/comments/%v/delete", chargebee.IDEscape(id)), nil)
 }

--- a/actions/coupon/coupon.go
+++ b/actions/coupon/coupon.go
@@ -2,9 +2,9 @@ package coupon
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/coupon"
-	"net/url"
 )
 
 func Create(params *coupon.CreateRequestParams) chargebee.RequestObj {
@@ -14,23 +14,23 @@ func CreateForItems(params *coupon.CreateForItemsRequestParams) chargebee.Reques
 	return chargebee.Send("POST", fmt.Sprintf("/coupons/create_for_items"), params)
 }
 func UpdateForItems(id string, params *coupon.UpdateForItemsRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/coupons/%v/update_for_items", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/coupons/%v/update_for_items", chargebee.IDEscape(id)), params)
 }
 func List(params *coupon.ListRequestParams) chargebee.RequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/coupons"), params)
 }
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/coupons/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/coupons/%v", chargebee.IDEscape(id)), nil)
 }
 func Update(id string, params *coupon.UpdateRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/coupons/%v", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/coupons/%v", chargebee.IDEscape(id)), params)
 }
 func Delete(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/coupons/%v/delete", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/coupons/%v/delete", chargebee.IDEscape(id)), nil)
 }
 func Copy(params *coupon.CopyRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/coupons/copy"), params)
 }
 func Unarchive(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/coupons/%v/unarchive", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/coupons/%v/unarchive", chargebee.IDEscape(id)), nil)
 }

--- a/actions/couponcode/coupon_code.go
+++ b/actions/couponcode/coupon_code.go
@@ -2,20 +2,20 @@ package couponcode
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/couponcode"
-	"net/url"
 )
 
 func Create(params *couponcode.CreateRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/coupon_codes"), params)
 }
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/coupon_codes/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/coupon_codes/%v", chargebee.IDEscape(id)), nil)
 }
 func List(params *couponcode.ListRequestParams) chargebee.RequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/coupon_codes"), params)
 }
 func Archive(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/coupon_codes/%v/archive", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/coupon_codes/%v/archive", chargebee.IDEscape(id)), nil)
 }

--- a/actions/couponset/coupon_set.go
+++ b/actions/couponset/coupon_set.go
@@ -2,29 +2,29 @@ package couponset
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/couponset"
-	"net/url"
 )
 
 func Create(params *couponset.CreateRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/coupon_sets"), params)
 }
 func AddCouponCodes(id string, params *couponset.AddCouponCodesRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/coupon_sets/%v/add_coupon_codes", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/coupon_sets/%v/add_coupon_codes", chargebee.IDEscape(id)), params)
 }
 func List(params *couponset.ListRequestParams) chargebee.RequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/coupon_sets"), params)
 }
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/coupon_sets/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/coupon_sets/%v", chargebee.IDEscape(id)), nil)
 }
 func Update(id string, params *couponset.UpdateRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/coupon_sets/%v/update", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/coupon_sets/%v/update", chargebee.IDEscape(id)), params)
 }
 func Delete(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/coupon_sets/%v/delete", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/coupon_sets/%v/delete", chargebee.IDEscape(id)), nil)
 }
 func DeleteUnusedCouponCodes(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/coupon_sets/%v/delete_unused_coupon_codes", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/coupon_sets/%v/delete_unused_coupon_codes", chargebee.IDEscape(id)), nil)
 }

--- a/actions/creditnote/credit_note.go
+++ b/actions/creditnote/credit_note.go
@@ -2,49 +2,49 @@ package creditnote
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/creditnote"
-	"net/url"
 )
 
 func Create(params *creditnote.CreateRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/credit_notes"), params)
 }
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/credit_notes/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/credit_notes/%v", chargebee.IDEscape(id)), nil)
 }
 func Pdf(id string, params *creditnote.PdfRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/credit_notes/%v/pdf", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/credit_notes/%v/pdf", chargebee.IDEscape(id)), params)
 }
 func DownloadEinvoice(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/credit_notes/%v/download_einvoice", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/credit_notes/%v/download_einvoice", chargebee.IDEscape(id)), nil)
 }
 func Refund(id string, params *creditnote.RefundRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/credit_notes/%v/refund", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/credit_notes/%v/refund", chargebee.IDEscape(id)), params)
 }
 func RecordRefund(id string, params *creditnote.RecordRefundRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/credit_notes/%v/record_refund", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/credit_notes/%v/record_refund", chargebee.IDEscape(id)), params)
 }
 func VoidCreditNote(id string, params *creditnote.VoidCreditNoteRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/credit_notes/%v/void", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/credit_notes/%v/void", chargebee.IDEscape(id)), params)
 }
 func List(params *creditnote.ListRequestParams) chargebee.RequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/credit_notes"), params)
 }
 func CreditNotesForCustomer(id string, params *creditnote.CreditNotesForCustomerRequestParams) chargebee.RequestObj {
-	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/credit_notes", url.PathEscape(id)), params)
+	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/credit_notes", chargebee.IDEscape(id)), params)
 }
 func Delete(id string, params *creditnote.DeleteRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/credit_notes/%v/delete", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/credit_notes/%v/delete", chargebee.IDEscape(id)), params)
 }
 func RemoveTaxWithheldRefund(id string, params *creditnote.RemoveTaxWithheldRefundRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/credit_notes/%v/remove_tax_withheld_refund", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/credit_notes/%v/remove_tax_withheld_refund", chargebee.IDEscape(id)), params)
 }
 func ResendEinvoice(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/credit_notes/%v/resend_einvoice", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/credit_notes/%v/resend_einvoice", chargebee.IDEscape(id)), nil)
 }
 func SendEinvoice(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/credit_notes/%v/send_einvoice", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/credit_notes/%v/send_einvoice", chargebee.IDEscape(id)), nil)
 }
 func ImportCreditNote(params *creditnote.ImportCreditNoteRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/credit_notes/import_credit_note"), params)

--- a/actions/customer/customer.go
+++ b/actions/customer/customer.go
@@ -2,9 +2,9 @@ package customer
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/customer"
-	"net/url"
 )
 
 func Create(params *customer.CreateRequestParams) chargebee.RequestObj {
@@ -14,71 +14,71 @@ func List(params *customer.ListRequestParams) chargebee.RequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/customers"), params)
 }
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/customers/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/customers/%v", chargebee.IDEscape(id)), nil)
 }
 func Update(id string, params *customer.UpdateRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v", chargebee.IDEscape(id)), params)
 }
 func UpdatePaymentMethod(id string, params *customer.UpdatePaymentMethodRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/update_payment_method", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/update_payment_method", chargebee.IDEscape(id)), params)
 }
 func UpdateBillingInfo(id string, params *customer.UpdateBillingInfoRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/update_billing_info", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/update_billing_info", chargebee.IDEscape(id)), params)
 }
 func ContactsForCustomer(id string, params *customer.ContactsForCustomerRequestParams) chargebee.RequestObj {
-	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/contacts", url.PathEscape(id)), params)
+	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/contacts", chargebee.IDEscape(id)), params)
 }
 func AssignPaymentRole(id string, params *customer.AssignPaymentRoleRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/assign_payment_role", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/assign_payment_role", chargebee.IDEscape(id)), params)
 }
 func AddContact(id string, params *customer.AddContactRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/add_contact", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/add_contact", chargebee.IDEscape(id)), params)
 }
 func UpdateContact(id string, params *customer.UpdateContactRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/update_contact", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/update_contact", chargebee.IDEscape(id)), params)
 }
 func DeleteContact(id string, params *customer.DeleteContactRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/delete_contact", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/delete_contact", chargebee.IDEscape(id)), params)
 }
 func AddPromotionalCredits(id string, params *customer.AddPromotionalCreditsRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/add_promotional_credits", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/add_promotional_credits", chargebee.IDEscape(id)), params)
 }
 func DeductPromotionalCredits(id string, params *customer.DeductPromotionalCreditsRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/deduct_promotional_credits", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/deduct_promotional_credits", chargebee.IDEscape(id)), params)
 }
 func SetPromotionalCredits(id string, params *customer.SetPromotionalCreditsRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/set_promotional_credits", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/set_promotional_credits", chargebee.IDEscape(id)), params)
 }
 func RecordExcessPayment(id string, params *customer.RecordExcessPaymentRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/record_excess_payment", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/record_excess_payment", chargebee.IDEscape(id)), params)
 }
 func CollectPayment(id string, params *customer.CollectPaymentRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/collect_payment", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/collect_payment", chargebee.IDEscape(id)), params)
 }
 func Delete(id string, params *customer.DeleteRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/delete", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/delete", chargebee.IDEscape(id)), params)
 }
 func Move(params *customer.MoveRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/move"), params)
 }
 func ChangeBillingDate(id string, params *customer.ChangeBillingDateRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/change_billing_date", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/change_billing_date", chargebee.IDEscape(id)), params)
 }
 func Merge(params *customer.MergeRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/merge"), params)
 }
 func ClearPersonalData(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/clear_personal_data", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/clear_personal_data", chargebee.IDEscape(id)), nil)
 }
 func Relationships(id string, params *customer.RelationshipsRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/relationships", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/relationships", chargebee.IDEscape(id)), params)
 }
 func DeleteRelationship(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/delete_relationship", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/delete_relationship", chargebee.IDEscape(id)), nil)
 }
 func Hierarchy(id string, params *customer.HierarchyRequestParams) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/customers/%v/hierarchy", url.PathEscape(id)), params)
+	return chargebee.Send("GET", fmt.Sprintf("/customers/%v/hierarchy", chargebee.IDEscape(id)), params)
 }
 func UpdateHierarchySettings(id string, params *customer.UpdateHierarchySettingsRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/update_hierarchy_settings", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/update_hierarchy_settings", chargebee.IDEscape(id)), params)
 }

--- a/actions/differentialprice/differential_price.go
+++ b/actions/differentialprice/differential_price.go
@@ -2,22 +2,22 @@ package differentialprice
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/differentialprice"
-	"net/url"
 )
 
 func Create(id string, params *differentialprice.CreateRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/item_prices/%v/differential_prices", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/item_prices/%v/differential_prices", chargebee.IDEscape(id)), params)
 }
 func Retrieve(id string, params *differentialprice.RetrieveRequestParams) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/differential_prices/%v", url.PathEscape(id)), params)
+	return chargebee.Send("GET", fmt.Sprintf("/differential_prices/%v", chargebee.IDEscape(id)), params)
 }
 func Update(id string, params *differentialprice.UpdateRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/differential_prices/%v", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/differential_prices/%v", chargebee.IDEscape(id)), params)
 }
 func Delete(id string, params *differentialprice.DeleteRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/differential_prices/%v/delete", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/differential_prices/%v/delete", chargebee.IDEscape(id)), params)
 }
 func List(params *differentialprice.ListRequestParams) chargebee.RequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/differential_prices"), params)

--- a/actions/entitlementoverride/entitlement_override.go
+++ b/actions/entitlementoverride/entitlement_override.go
@@ -2,14 +2,14 @@ package entitlementoverride
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/entitlementoverride"
-	"net/url"
 )
 
 func AddEntitlementOverrideForSubscription(id string, params *entitlementoverride.AddEntitlementOverrideForSubscriptionRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/entitlement_overrides", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/entitlement_overrides", chargebee.IDEscape(id)), params)
 }
 func ListEntitlementOverrideForSubscription(id string, params *entitlementoverride.ListEntitlementOverrideForSubscriptionRequestParams) chargebee.RequestObj {
-	return chargebee.SendList("GET", fmt.Sprintf("/subscriptions/%v/entitlement_overrides", url.PathEscape(id)), params)
+	return chargebee.SendList("GET", fmt.Sprintf("/subscriptions/%v/entitlement_overrides", chargebee.IDEscape(id)), params)
 }

--- a/actions/estimate/estimate.go
+++ b/actions/estimate/estimate.go
@@ -2,9 +2,9 @@ package estimate
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/estimate"
-	"net/url"
 )
 
 func CreateSubscription(params *estimate.CreateSubscriptionRequestParams) chargebee.RequestObj {
@@ -14,10 +14,10 @@ func CreateSubItemEstimate(params *estimate.CreateSubItemEstimateRequestParams) 
 	return chargebee.Send("POST", fmt.Sprintf("/estimates/create_subscription_for_items"), params)
 }
 func CreateSubForCustomerEstimate(id string, params *estimate.CreateSubForCustomerEstimateRequestParams) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/customers/%v/create_subscription_estimate", url.PathEscape(id)), params)
+	return chargebee.Send("GET", fmt.Sprintf("/customers/%v/create_subscription_estimate", chargebee.IDEscape(id)), params)
 }
 func CreateSubItemForCustomerEstimate(id string, params *estimate.CreateSubItemForCustomerEstimateRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/create_subscription_for_items_estimate", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/create_subscription_for_items_estimate", chargebee.IDEscape(id)), params)
 }
 func UpdateSubscription(params *estimate.UpdateSubscriptionRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/estimates/update_subscription"), params)
@@ -26,31 +26,31 @@ func UpdateSubscriptionForItems(params *estimate.UpdateSubscriptionForItemsReque
 	return chargebee.Send("POST", fmt.Sprintf("/estimates/update_subscription_for_items"), params)
 }
 func RenewalEstimate(id string, params *estimate.RenewalEstimateRequestParams) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/subscriptions/%v/renewal_estimate", url.PathEscape(id)), params)
+	return chargebee.Send("GET", fmt.Sprintf("/subscriptions/%v/renewal_estimate", chargebee.IDEscape(id)), params)
 }
 func AdvanceInvoiceEstimate(id string, params *estimate.AdvanceInvoiceEstimateRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/advance_invoice_estimate", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/advance_invoice_estimate", chargebee.IDEscape(id)), params)
 }
 func RegenerateInvoiceEstimate(id string, params *estimate.RegenerateInvoiceEstimateRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/regenerate_invoice_estimate", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/regenerate_invoice_estimate", chargebee.IDEscape(id)), params)
 }
 func UpcomingInvoicesEstimate(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/customers/%v/upcoming_invoices_estimate", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/customers/%v/upcoming_invoices_estimate", chargebee.IDEscape(id)), nil)
 }
 func ChangeTermEnd(id string, params *estimate.ChangeTermEndRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/change_term_end_estimate", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/change_term_end_estimate", chargebee.IDEscape(id)), params)
 }
 func CancelSubscription(id string, params *estimate.CancelSubscriptionRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/cancel_subscription_estimate", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/cancel_subscription_estimate", chargebee.IDEscape(id)), params)
 }
 func CancelSubscriptionForItems(id string, params *estimate.CancelSubscriptionForItemsRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/cancel_subscription_for_items_estimate", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/cancel_subscription_for_items_estimate", chargebee.IDEscape(id)), params)
 }
 func PauseSubscription(id string, params *estimate.PauseSubscriptionRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/pause_subscription_estimate", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/pause_subscription_estimate", chargebee.IDEscape(id)), params)
 }
 func ResumeSubscription(id string, params *estimate.ResumeSubscriptionRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/resume_subscription_estimate", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/resume_subscription_estimate", chargebee.IDEscape(id)), params)
 }
 func GiftSubscription(params *estimate.GiftSubscriptionRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/estimates/gift_subscription"), params)

--- a/actions/event/event.go
+++ b/actions/event/event.go
@@ -4,17 +4,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/event"
-	"net/url"
-	"strings"
 )
 
 func List(params *event.ListRequestParams) chargebee.RequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/events"), params)
 }
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/events/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/events/%v", chargebee.IDEscape(id)), nil)
 }
 func Content(event event.Event) *chargebee.Result {
 	content := &chargebee.Result{}

--- a/actions/export/export.go
+++ b/actions/export/export.go
@@ -1,17 +1,17 @@
 package export
 
 import (
+	"errors"
 	"fmt"
+	"time"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/export"
-	"net/url"
-	"errors"
 	exportEnum "github.com/chargebee/chargebee-go/v3/models/export/enum"
-	"time"
 )
 
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/exports/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/exports/%v", chargebee.IDEscape(id)), nil)
 }
 func RevenueRecognition(params *export.RevenueRecognitionRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/exports/revenue_recognition"), params)

--- a/actions/feature/feature.go
+++ b/actions/feature/feature.go
@@ -2,9 +2,9 @@ package feature
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/feature"
-	"net/url"
 )
 
 func List(params *feature.ListRequestParams) chargebee.RequestObj {
@@ -14,20 +14,20 @@ func Create(params *feature.CreateRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/features"), params)
 }
 func Update(id string, params *feature.UpdateRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/features/%v", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/features/%v", chargebee.IDEscape(id)), params)
 }
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/features/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/features/%v", chargebee.IDEscape(id)), nil)
 }
 func Delete(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/features/%v/delete", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/features/%v/delete", chargebee.IDEscape(id)), nil)
 }
 func Activate(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/features/%v/activate_command", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/features/%v/activate_command", chargebee.IDEscape(id)), nil)
 }
 func Archive(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/features/%v/archive_command", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/features/%v/archive_command", chargebee.IDEscape(id)), nil)
 }
 func Reactivate(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/features/%v/reactivate_command", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/features/%v/reactivate_command", chargebee.IDEscape(id)), nil)
 }

--- a/actions/gift/gift.go
+++ b/actions/gift/gift.go
@@ -2,9 +2,9 @@ package gift
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/gift"
-	"net/url"
 )
 
 func Create(params *gift.CreateRequestParams) chargebee.RequestObj {
@@ -14,17 +14,17 @@ func CreateForItems(params *gift.CreateForItemsRequestParams) chargebee.RequestO
 	return chargebee.Send("POST", fmt.Sprintf("/gifts/create_for_items"), params)
 }
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/gifts/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/gifts/%v", chargebee.IDEscape(id)), nil)
 }
 func List(params *gift.ListRequestParams) chargebee.RequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/gifts"), params)
 }
 func Claim(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/gifts/%v/claim", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/gifts/%v/claim", chargebee.IDEscape(id)), nil)
 }
 func Cancel(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/gifts/%v/cancel", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/gifts/%v/cancel", chargebee.IDEscape(id)), nil)
 }
 func UpdateGift(id string, params *gift.UpdateGiftRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/gifts/%v/update_gift", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/gifts/%v/update_gift", chargebee.IDEscape(id)), params)
 }

--- a/actions/hostedpage/hosted_page.go
+++ b/actions/hostedpage/hosted_page.go
@@ -3,9 +3,9 @@ package hostedpage
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/hostedpage"
-	"net/url"
 )
 
 func CheckoutNew(params *hostedpage.CheckoutNewRequestParams) chargebee.RequestObj {
@@ -57,10 +57,10 @@ func RetrieveAgreementPdf(params *hostedpage.RetrieveAgreementPdfRequestParams) 
 	return chargebee.Send("POST", fmt.Sprintf("/hosted_pages/retrieve_agreement_pdf"), params)
 }
 func Acknowledge(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/hosted_pages/%v/acknowledge", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/hosted_pages/%v/acknowledge", chargebee.IDEscape(id)), nil)
 }
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/hosted_pages/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/hosted_pages/%v", chargebee.IDEscape(id)), nil)
 }
 func List(params *hostedpage.ListRequestParams) chargebee.RequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/hosted_pages"), params)

--- a/actions/inappsubscription/in_app_subscription.go
+++ b/actions/inappsubscription/in_app_subscription.go
@@ -2,20 +2,20 @@ package inappsubscription
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/inappsubscription"
-	"net/url"
 )
 
 func ProcessReceipt(id string, params *inappsubscription.ProcessReceiptRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/in_app_subscriptions/%v/process_purchase_command", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/in_app_subscriptions/%v/process_purchase_command", chargebee.IDEscape(id)), params)
 }
 func ImportReceipt(id string, params *inappsubscription.ImportReceiptRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/in_app_subscriptions/%v/import_receipt", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/in_app_subscriptions/%v/import_receipt", chargebee.IDEscape(id)), params)
 }
 func ImportSubscription(id string, params *inappsubscription.ImportSubscriptionRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/in_app_subscriptions/%v/import_subscription", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/in_app_subscriptions/%v/import_subscription", chargebee.IDEscape(id)), params)
 }
 func RetrieveStoreSubs(id string, params *inappsubscription.RetrieveStoreSubsRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/in_app_subscriptions/%v/retrieve", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/in_app_subscriptions/%v/retrieve", chargebee.IDEscape(id)), params)
 }

--- a/actions/invoice/invoice.go
+++ b/actions/invoice/invoice.go
@@ -2,9 +2,9 @@ package invoice
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/invoice"
-	"net/url"
 )
 
 func Create(params *invoice.CreateRequestParams) chargebee.RequestObj {
@@ -23,95 +23,95 @@ func CreateForChargeItem(params *invoice.CreateForChargeItemRequestParams) charg
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/create_for_charge_item"), params)
 }
 func StopDunning(id string, params *invoice.StopDunningRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/stop_dunning", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/stop_dunning", chargebee.IDEscape(id)), params)
 }
 func ImportInvoice(params *invoice.ImportInvoiceRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/import_invoice"), params)
 }
 func ApplyPayments(id string, params *invoice.ApplyPaymentsRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/apply_payments", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/apply_payments", chargebee.IDEscape(id)), params)
 }
 func SyncUsages(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/sync_usages", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/sync_usages", chargebee.IDEscape(id)), nil)
 }
 func DeleteLineItems(id string, params *invoice.DeleteLineItemsRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/delete_line_items", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/delete_line_items", chargebee.IDEscape(id)), params)
 }
 func ApplyCredits(id string, params *invoice.ApplyCreditsRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/apply_credits", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/apply_credits", chargebee.IDEscape(id)), params)
 }
 func List(params *invoice.ListRequestParams) chargebee.RequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/invoices"), params)
 }
 func InvoicesForCustomer(id string, params *invoice.InvoicesForCustomerRequestParams) chargebee.RequestObj {
-	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/invoices", url.PathEscape(id)), params)
+	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/invoices", chargebee.IDEscape(id)), params)
 }
 func InvoicesForSubscription(id string, params *invoice.InvoicesForSubscriptionRequestParams) chargebee.RequestObj {
-	return chargebee.SendList("GET", fmt.Sprintf("/subscriptions/%v/invoices", url.PathEscape(id)), params)
+	return chargebee.SendList("GET", fmt.Sprintf("/subscriptions/%v/invoices", chargebee.IDEscape(id)), params)
 }
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/invoices/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/invoices/%v", chargebee.IDEscape(id)), nil)
 }
 func Pdf(id string, params *invoice.PdfRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/pdf", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/pdf", chargebee.IDEscape(id)), params)
 }
 func DownloadEinvoice(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/invoices/%v/download_einvoice", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/invoices/%v/download_einvoice", chargebee.IDEscape(id)), nil)
 }
 func ListPaymentReferenceNumbers(params *invoice.ListPaymentReferenceNumbersRequestParams) chargebee.RequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/invoices/payment_reference_numbers"), params)
 }
 func AddCharge(id string, params *invoice.AddChargeRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/add_charge", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/add_charge", chargebee.IDEscape(id)), params)
 }
 func AddAddonCharge(id string, params *invoice.AddAddonChargeRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/add_addon_charge", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/add_addon_charge", chargebee.IDEscape(id)), params)
 }
 func AddChargeItem(id string, params *invoice.AddChargeItemRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/add_charge_item", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/add_charge_item", chargebee.IDEscape(id)), params)
 }
 func Close(id string, params *invoice.CloseRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/close", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/close", chargebee.IDEscape(id)), params)
 }
 func CollectPayment(id string, params *invoice.CollectPaymentRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/collect_payment", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/collect_payment", chargebee.IDEscape(id)), params)
 }
 func RecordPayment(id string, params *invoice.RecordPaymentRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/record_payment", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/record_payment", chargebee.IDEscape(id)), params)
 }
 func RecordTaxWithheld(id string, params *invoice.RecordTaxWithheldRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/record_tax_withheld", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/record_tax_withheld", chargebee.IDEscape(id)), params)
 }
 func RemoveTaxWithheld(id string, params *invoice.RemoveTaxWithheldRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/remove_tax_withheld", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/remove_tax_withheld", chargebee.IDEscape(id)), params)
 }
 func Refund(id string, params *invoice.RefundRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/refund", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/refund", chargebee.IDEscape(id)), params)
 }
 func RecordRefund(id string, params *invoice.RecordRefundRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/record_refund", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/record_refund", chargebee.IDEscape(id)), params)
 }
 func RemovePayment(id string, params *invoice.RemovePaymentRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/remove_payment", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/remove_payment", chargebee.IDEscape(id)), params)
 }
 func RemoveCreditNote(id string, params *invoice.RemoveCreditNoteRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/remove_credit_note", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/remove_credit_note", chargebee.IDEscape(id)), params)
 }
 func VoidInvoice(id string, params *invoice.VoidInvoiceRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/void", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/void", chargebee.IDEscape(id)), params)
 }
 func WriteOff(id string, params *invoice.WriteOffRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/write_off", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/write_off", chargebee.IDEscape(id)), params)
 }
 func Delete(id string, params *invoice.DeleteRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/delete", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/delete", chargebee.IDEscape(id)), params)
 }
 func UpdateDetails(id string, params *invoice.UpdateDetailsRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/update_details", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/update_details", chargebee.IDEscape(id)), params)
 }
 func ResendEinvoice(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/resend_einvoice", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/resend_einvoice", chargebee.IDEscape(id)), nil)
 }
 func SendEinvoice(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/send_einvoice", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/send_einvoice", chargebee.IDEscape(id)), nil)
 }

--- a/actions/item/item.go
+++ b/actions/item/item.go
@@ -2,23 +2,23 @@ package item
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/item"
-	"net/url"
 )
 
 func Create(params *item.CreateRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/items"), params)
 }
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/items/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/items/%v", chargebee.IDEscape(id)), nil)
 }
 func Update(id string, params *item.UpdateRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/items/%v", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/items/%v", chargebee.IDEscape(id)), params)
 }
 func List(params *item.ListRequestParams) chargebee.RequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/items"), params)
 }
 func Delete(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/items/%v/delete", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/items/%v/delete", chargebee.IDEscape(id)), nil)
 }

--- a/actions/itementitlement/item_entitlement.go
+++ b/actions/itementitlement/item_entitlement.go
@@ -2,20 +2,20 @@ package itementitlement
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/itementitlement"
-	"net/url"
 )
 
 func ItemEntitlementsForItem(id string, params *itementitlement.ItemEntitlementsForItemRequestParams) chargebee.RequestObj {
-	return chargebee.SendList("GET", fmt.Sprintf("/items/%v/item_entitlements", url.PathEscape(id)), params)
+	return chargebee.SendList("GET", fmt.Sprintf("/items/%v/item_entitlements", chargebee.IDEscape(id)), params)
 }
 func ItemEntitlementsForFeature(id string, params *itementitlement.ItemEntitlementsForFeatureRequestParams) chargebee.RequestObj {
-	return chargebee.SendList("GET", fmt.Sprintf("/features/%v/item_entitlements", url.PathEscape(id)), params)
+	return chargebee.SendList("GET", fmt.Sprintf("/features/%v/item_entitlements", chargebee.IDEscape(id)), params)
 }
 func AddItemEntitlements(id string, params *itementitlement.AddItemEntitlementsRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/features/%v/item_entitlements", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/features/%v/item_entitlements", chargebee.IDEscape(id)), params)
 }
 func UpsertOrRemoveItemEntitlementsForItem(id string, params *itementitlement.UpsertOrRemoveItemEntitlementsForItemRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/items/%v/item_entitlements", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/items/%v/item_entitlements", chargebee.IDEscape(id)), params)
 }

--- a/actions/itemfamily/item_family.go
+++ b/actions/itemfamily/item_family.go
@@ -2,23 +2,23 @@ package itemfamily
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/itemfamily"
-	"net/url"
 )
 
 func Create(params *itemfamily.CreateRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/item_families"), params)
 }
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/item_families/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/item_families/%v", chargebee.IDEscape(id)), nil)
 }
 func List(params *itemfamily.ListRequestParams) chargebee.RequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/item_families"), params)
 }
 func Update(id string, params *itemfamily.UpdateRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/item_families/%v", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/item_families/%v", chargebee.IDEscape(id)), params)
 }
 func Delete(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/item_families/%v/delete", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/item_families/%v/delete", chargebee.IDEscape(id)), nil)
 }

--- a/actions/itemprice/item_price.go
+++ b/actions/itemprice/item_price.go
@@ -2,29 +2,29 @@ package itemprice
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/itemprice"
-	"net/url"
 )
 
 func Create(params *itemprice.CreateRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/item_prices"), params)
 }
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/item_prices/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/item_prices/%v", chargebee.IDEscape(id)), nil)
 }
 func Update(id string, params *itemprice.UpdateRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/item_prices/%v", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/item_prices/%v", chargebee.IDEscape(id)), params)
 }
 func List(params *itemprice.ListRequestParams) chargebee.RequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/item_prices"), params)
 }
 func Delete(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/item_prices/%v/delete", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/item_prices/%v/delete", chargebee.IDEscape(id)), nil)
 }
 func FindApplicableItems(id string, params *itemprice.FindApplicableItemsRequestParams) chargebee.RequestObj {
-	return chargebee.SendList("GET", fmt.Sprintf("/item_prices/%v/applicable_items", url.PathEscape(id)), params)
+	return chargebee.SendList("GET", fmt.Sprintf("/item_prices/%v/applicable_items", chargebee.IDEscape(id)), params)
 }
 func FindApplicableItemPrices(id string, params *itemprice.FindApplicableItemPricesRequestParams) chargebee.RequestObj {
-	return chargebee.SendList("GET", fmt.Sprintf("/item_prices/%v/applicable_item_prices", url.PathEscape(id)), params)
+	return chargebee.SendList("GET", fmt.Sprintf("/item_prices/%v/applicable_item_prices", chargebee.IDEscape(id)), params)
 }

--- a/actions/order/order.go
+++ b/actions/order/order.go
@@ -2,44 +2,44 @@ package order
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/order"
-	"net/url"
 )
 
 func Create(params *order.CreateRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/orders"), params)
 }
 func Update(id string, params *order.UpdateRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/orders/%v", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/orders/%v", chargebee.IDEscape(id)), params)
 }
 func ImportOrder(params *order.ImportOrderRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/orders/import_order"), params)
 }
 func AssignOrderNumber(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/orders/%v/assign_order_number", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/orders/%v/assign_order_number", chargebee.IDEscape(id)), nil)
 }
 func Cancel(id string, params *order.CancelRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/orders/%v/cancel", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/orders/%v/cancel", chargebee.IDEscape(id)), params)
 }
 func CreateRefundableCreditNote(id string, params *order.CreateRefundableCreditNoteRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/orders/%v/create_refundable_credit_note", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/orders/%v/create_refundable_credit_note", chargebee.IDEscape(id)), params)
 }
 func Reopen(id string, params *order.ReopenRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/orders/%v/reopen", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/orders/%v/reopen", chargebee.IDEscape(id)), params)
 }
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/orders/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/orders/%v", chargebee.IDEscape(id)), nil)
 }
 func Delete(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/orders/%v/delete", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/orders/%v/delete", chargebee.IDEscape(id)), nil)
 }
 func List(params *order.ListRequestParams) chargebee.RequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/orders"), params)
 }
 func OrdersForInvoice(id string, params *order.OrdersForInvoiceRequestParams) chargebee.RequestObj {
-	return chargebee.SendList("GET", fmt.Sprintf("/invoices/%v/orders", url.PathEscape(id)), params)
+	return chargebee.SendList("GET", fmt.Sprintf("/invoices/%v/orders", chargebee.IDEscape(id)), params)
 }
 func Resend(id string, params *order.ResendRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/orders/%v/resend", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/orders/%v/resend", chargebee.IDEscape(id)), params)
 }

--- a/actions/paymentintent/payment_intent.go
+++ b/actions/paymentintent/payment_intent.go
@@ -2,17 +2,17 @@ package paymentintent
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/paymentintent"
-	"net/url"
 )
 
 func Create(params *paymentintent.CreateRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/payment_intents"), params)
 }
 func Update(id string, params *paymentintent.UpdateRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/payment_intents/%v", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/payment_intents/%v", chargebee.IDEscape(id)), params)
 }
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/payment_intents/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/payment_intents/%v", chargebee.IDEscape(id)), nil)
 }

--- a/actions/paymentsource/payment_source.go
+++ b/actions/paymentsource/payment_source.go
@@ -2,9 +2,9 @@ package paymentsource
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/paymentsource"
-	"net/url"
 )
 
 func CreateUsingTempToken(params *paymentsource.CreateUsingTempTokenRequestParams) chargebee.RequestObj {
@@ -29,29 +29,29 @@ func CreateBankAccount(params *paymentsource.CreateBankAccountRequestParams) cha
 	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/create_bank_account"), params)
 }
 func UpdateCard(id string, params *paymentsource.UpdateCardRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/%v/update_card", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/%v/update_card", chargebee.IDEscape(id)), params)
 }
 func UpdateBankAccount(id string, params *paymentsource.UpdateBankAccountRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/%v/update_bank_account", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/%v/update_bank_account", chargebee.IDEscape(id)), params)
 }
 func VerifyBankAccount(id string, params *paymentsource.VerifyBankAccountRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/%v/verify_bank_account", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/%v/verify_bank_account", chargebee.IDEscape(id)), params)
 }
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/payment_sources/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/payment_sources/%v", chargebee.IDEscape(id)), nil)
 }
 func List(params *paymentsource.ListRequestParams) chargebee.RequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/payment_sources"), params)
 }
 func SwitchGatewayAccount(id string, params *paymentsource.SwitchGatewayAccountRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/%v/switch_gateway_account", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/%v/switch_gateway_account", chargebee.IDEscape(id)), params)
 }
 func ExportPaymentSource(id string, params *paymentsource.ExportPaymentSourceRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/%v/export_payment_source", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/%v/export_payment_source", chargebee.IDEscape(id)), params)
 }
 func Delete(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/%v/delete", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/%v/delete", chargebee.IDEscape(id)), nil)
 }
 func DeleteLocal(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/%v/delete_local", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/%v/delete_local", chargebee.IDEscape(id)), nil)
 }

--- a/actions/paymentvoucher/payment_voucher.go
+++ b/actions/paymentvoucher/payment_voucher.go
@@ -2,20 +2,20 @@ package paymentvoucher
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/paymentvoucher"
-	"net/url"
 )
 
 func Create(params *paymentvoucher.CreateRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/payment_vouchers"), params)
 }
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/payment_vouchers/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/payment_vouchers/%v", chargebee.IDEscape(id)), nil)
 }
 func Payment_vouchersForInvoice(id string, params *paymentvoucher.PaymentVouchersForInvoiceRequestParams) chargebee.RequestObj {
-	return chargebee.SendList("GET", fmt.Sprintf("/invoices/%v/payment_vouchers", url.PathEscape(id)), params)
+	return chargebee.SendList("GET", fmt.Sprintf("/invoices/%v/payment_vouchers", chargebee.IDEscape(id)), params)
 }
 func Payment_vouchersForCustomer(id string, params *paymentvoucher.PaymentVouchersForCustomerRequestParams) chargebee.RequestObj {
-	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/payment_vouchers", url.PathEscape(id)), params)
+	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/payment_vouchers", chargebee.IDEscape(id)), params)
 }

--- a/actions/plan/plan.go
+++ b/actions/plan/plan.go
@@ -2,29 +2,29 @@ package plan
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/plan"
-	"net/url"
 )
 
 func Create(params *plan.CreateRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/plans"), params)
 }
 func Update(id string, params *plan.UpdateRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/plans/%v", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/plans/%v", chargebee.IDEscape(id)), params)
 }
 func List(params *plan.ListRequestParams) chargebee.RequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/plans"), params)
 }
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/plans/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/plans/%v", chargebee.IDEscape(id)), nil)
 }
 func Delete(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/plans/%v/delete", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/plans/%v/delete", chargebee.IDEscape(id)), nil)
 }
 func Copy(params *plan.CopyRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/plans/copy"), params)
 }
 func Unarchive(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/plans/%v/unarchive", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/plans/%v/unarchive", chargebee.IDEscape(id)), nil)
 }

--- a/actions/portalsession/portal_session.go
+++ b/actions/portalsession/portal_session.go
@@ -2,20 +2,20 @@ package portalsession
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/portalsession"
-	"net/url"
 )
 
 func Create(params *portalsession.CreateRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/portal_sessions"), params)
 }
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/portal_sessions/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/portal_sessions/%v", chargebee.IDEscape(id)), nil)
 }
 func Logout(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/portal_sessions/%v/logout", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/portal_sessions/%v/logout", chargebee.IDEscape(id)), nil)
 }
 func Activate(id string, params *portalsession.ActivateRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/portal_sessions/%v/activate", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/portal_sessions/%v/activate", chargebee.IDEscape(id)), params)
 }

--- a/actions/promotionalcredit/promotional_credit.go
+++ b/actions/promotionalcredit/promotional_credit.go
@@ -2,9 +2,9 @@ package promotionalcredit
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/promotionalcredit"
-	"net/url"
 )
 
 func Add(params *promotionalcredit.AddRequestParams) chargebee.RequestObj {
@@ -20,5 +20,5 @@ func List(params *promotionalcredit.ListRequestParams) chargebee.RequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/promotional_credits"), params)
 }
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/promotional_credits/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/promotional_credits/%v", chargebee.IDEscape(id)), nil)
 }

--- a/actions/quote/quote.go
+++ b/actions/quote/quote.go
@@ -2,68 +2,68 @@ package quote
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/quote"
-	"net/url"
 )
 
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/quotes/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/quotes/%v", chargebee.IDEscape(id)), nil)
 }
 func CreateSubForCustomerQuote(id string, params *quote.CreateSubForCustomerQuoteRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/create_subscription_quote", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/create_subscription_quote", chargebee.IDEscape(id)), params)
 }
 func EditCreateSubForCustomerQuote(id string, params *quote.EditCreateSubForCustomerQuoteRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/edit_create_subscription_quote", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/edit_create_subscription_quote", chargebee.IDEscape(id)), params)
 }
 func UpdateSubscriptionQuote(params *quote.UpdateSubscriptionQuoteRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/quotes/update_subscription_quote"), params)
 }
 func EditUpdateSubscriptionQuote(id string, params *quote.EditUpdateSubscriptionQuoteRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/edit_update_subscription_quote", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/edit_update_subscription_quote", chargebee.IDEscape(id)), params)
 }
 func CreateForOnetimeCharges(params *quote.CreateForOnetimeChargesRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/quotes/create_for_onetime_charges"), params)
 }
 func EditOneTimeQuote(id string, params *quote.EditOneTimeQuoteRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/edit_one_time_quote", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/edit_one_time_quote", chargebee.IDEscape(id)), params)
 }
 func CreateSubItemsForCustomerQuote(id string, params *quote.CreateSubItemsForCustomerQuoteRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/create_subscription_quote_for_items", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/create_subscription_quote_for_items", chargebee.IDEscape(id)), params)
 }
 func EditCreateSubCustomerQuoteForItems(id string, params *quote.EditCreateSubCustomerQuoteForItemsRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/edit_create_subscription_quote_for_items", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/edit_create_subscription_quote_for_items", chargebee.IDEscape(id)), params)
 }
 func UpdateSubscriptionQuoteForItems(params *quote.UpdateSubscriptionQuoteForItemsRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/quotes/update_subscription_quote_for_items"), params)
 }
 func EditUpdateSubscriptionQuoteForItems(id string, params *quote.EditUpdateSubscriptionQuoteForItemsRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/edit_update_subscription_quote_for_items", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/edit_update_subscription_quote_for_items", chargebee.IDEscape(id)), params)
 }
 func CreateForChargeItemsAndCharges(params *quote.CreateForChargeItemsAndChargesRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/quotes/create_for_charge_items_and_charges"), params)
 }
 func EditForChargeItemsAndCharges(id string, params *quote.EditForChargeItemsAndChargesRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/edit_for_charge_items_and_charges", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/edit_for_charge_items_and_charges", chargebee.IDEscape(id)), params)
 }
 func List(params *quote.ListRequestParams) chargebee.RequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/quotes"), params)
 }
 func QuoteLineGroupsForQuote(id string, params *quote.QuoteLineGroupsForQuoteRequestParams) chargebee.RequestObj {
-	return chargebee.SendList("GET", fmt.Sprintf("/quotes/%v/quote_line_groups", url.PathEscape(id)), params)
+	return chargebee.SendList("GET", fmt.Sprintf("/quotes/%v/quote_line_groups", chargebee.IDEscape(id)), params)
 }
 func Convert(id string, params *quote.ConvertRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/convert", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/convert", chargebee.IDEscape(id)), params)
 }
 func UpdateStatus(id string, params *quote.UpdateStatusRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/update_status", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/update_status", chargebee.IDEscape(id)), params)
 }
 func ExtendExpiryDate(id string, params *quote.ExtendExpiryDateRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/extend_expiry_date", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/extend_expiry_date", chargebee.IDEscape(id)), params)
 }
 func Delete(id string, params *quote.DeleteRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/delete", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/delete", chargebee.IDEscape(id)), params)
 }
 func Pdf(id string, params *quote.PdfRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/pdf", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/pdf", chargebee.IDEscape(id)), params)
 }

--- a/actions/subscription/subscription.go
+++ b/actions/subscription/subscription.go
@@ -2,116 +2,116 @@ package subscription
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/subscription"
-	"net/url"
 )
 
 func Create(params *subscription.CreateRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions"), params)
 }
 func CreateForCustomer(id string, params *subscription.CreateForCustomerRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/subscriptions", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/subscriptions", chargebee.IDEscape(id)), params)
 }
 func CreateWithItems(id string, params *subscription.CreateWithItemsRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/subscription_for_items", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/subscription_for_items", chargebee.IDEscape(id)), params)
 }
 func List(params *subscription.ListRequestParams) chargebee.RequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/subscriptions"), params)
 }
 func SubscriptionsForCustomer(id string, params *subscription.SubscriptionsForCustomerRequestParams) chargebee.RequestObj {
-	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/subscriptions", url.PathEscape(id)), params)
+	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/subscriptions", chargebee.IDEscape(id)), params)
 }
 func ContractTermsForSubscription(id string, params *subscription.ContractTermsForSubscriptionRequestParams) chargebee.RequestObj {
-	return chargebee.SendList("GET", fmt.Sprintf("/subscriptions/%v/contract_terms", url.PathEscape(id)), params)
+	return chargebee.SendList("GET", fmt.Sprintf("/subscriptions/%v/contract_terms", chargebee.IDEscape(id)), params)
 }
 func ListDiscounts(id string, params *subscription.ListDiscountsRequestParams) chargebee.RequestObj {
-	return chargebee.SendList("GET", fmt.Sprintf("/subscriptions/%v/discounts", url.PathEscape(id)), params)
+	return chargebee.SendList("GET", fmt.Sprintf("/subscriptions/%v/discounts", chargebee.IDEscape(id)), params)
 }
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/subscriptions/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/subscriptions/%v", chargebee.IDEscape(id)), nil)
 }
 func RetrieveWithScheduledChanges(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/subscriptions/%v/retrieve_with_scheduled_changes", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/subscriptions/%v/retrieve_with_scheduled_changes", chargebee.IDEscape(id)), nil)
 }
 func RemoveScheduledChanges(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/remove_scheduled_changes", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/remove_scheduled_changes", chargebee.IDEscape(id)), nil)
 }
 func RemoveScheduledCancellation(id string, params *subscription.RemoveScheduledCancellationRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/remove_scheduled_cancellation", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/remove_scheduled_cancellation", chargebee.IDEscape(id)), params)
 }
 func RemoveCoupons(id string, params *subscription.RemoveCouponsRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/remove_coupons", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/remove_coupons", chargebee.IDEscape(id)), params)
 }
 func Update(id string, params *subscription.UpdateRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v", chargebee.IDEscape(id)), params)
 }
 func UpdateForItems(id string, params *subscription.UpdateForItemsRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/update_for_items", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/update_for_items", chargebee.IDEscape(id)), params)
 }
 func ChangeTermEnd(id string, params *subscription.ChangeTermEndRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/change_term_end", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/change_term_end", chargebee.IDEscape(id)), params)
 }
 func Reactivate(id string, params *subscription.ReactivateRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/reactivate", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/reactivate", chargebee.IDEscape(id)), params)
 }
 func AddChargeAtTermEnd(id string, params *subscription.AddChargeAtTermEndRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/add_charge_at_term_end", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/add_charge_at_term_end", chargebee.IDEscape(id)), params)
 }
 func ChargeAddonAtTermEnd(id string, params *subscription.ChargeAddonAtTermEndRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/charge_addon_at_term_end", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/charge_addon_at_term_end", chargebee.IDEscape(id)), params)
 }
 func ChargeFutureRenewals(id string, params *subscription.ChargeFutureRenewalsRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/charge_future_renewals", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/charge_future_renewals", chargebee.IDEscape(id)), params)
 }
 func EditAdvanceInvoiceSchedule(id string, params *subscription.EditAdvanceInvoiceScheduleRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/edit_advance_invoice_schedule", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/edit_advance_invoice_schedule", chargebee.IDEscape(id)), params)
 }
 func RetrieveAdvanceInvoiceSchedule(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/subscriptions/%v/retrieve_advance_invoice_schedule", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/subscriptions/%v/retrieve_advance_invoice_schedule", chargebee.IDEscape(id)), nil)
 }
 func RemoveAdvanceInvoiceSchedule(id string, params *subscription.RemoveAdvanceInvoiceScheduleRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/remove_advance_invoice_schedule", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/remove_advance_invoice_schedule", chargebee.IDEscape(id)), params)
 }
 func RegenerateInvoice(id string, params *subscription.RegenerateInvoiceRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/regenerate_invoice", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/regenerate_invoice", chargebee.IDEscape(id)), params)
 }
 func ImportSubscription(params *subscription.ImportSubscriptionRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/import_subscription"), params)
 }
 func ImportForCustomer(id string, params *subscription.ImportForCustomerRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/import_subscription", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/import_subscription", chargebee.IDEscape(id)), params)
 }
 func ImportContractTerm(id string, params *subscription.ImportContractTermRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/import_contract_term", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/import_contract_term", chargebee.IDEscape(id)), params)
 }
 func ImportUnbilledCharges(id string, params *subscription.ImportUnbilledChargesRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/import_unbilled_charges", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/import_unbilled_charges", chargebee.IDEscape(id)), params)
 }
 func ImportForItems(id string, params *subscription.ImportForItemsRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/import_for_items", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/import_for_items", chargebee.IDEscape(id)), params)
 }
 func OverrideBillingProfile(id string, params *subscription.OverrideBillingProfileRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/override_billing_profile", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/override_billing_profile", chargebee.IDEscape(id)), params)
 }
 func Delete(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/delete", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/delete", chargebee.IDEscape(id)), nil)
 }
 func Pause(id string, params *subscription.PauseRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/pause", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/pause", chargebee.IDEscape(id)), params)
 }
 func Cancel(id string, params *subscription.CancelRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/cancel", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/cancel", chargebee.IDEscape(id)), params)
 }
 func CancelForItems(id string, params *subscription.CancelForItemsRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/cancel_for_items", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/cancel_for_items", chargebee.IDEscape(id)), params)
 }
 func Resume(id string, params *subscription.ResumeRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/resume", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/resume", chargebee.IDEscape(id)), params)
 }
 func RemoveScheduledPause(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/remove_scheduled_pause", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/remove_scheduled_pause", chargebee.IDEscape(id)), nil)
 }
 func RemoveScheduledResumption(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/remove_scheduled_resumption", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/remove_scheduled_resumption", chargebee.IDEscape(id)), nil)
 }

--- a/actions/subscriptionentitlement/subscription_entitlement.go
+++ b/actions/subscriptionentitlement/subscription_entitlement.go
@@ -2,14 +2,14 @@ package subscriptionentitlement
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/subscriptionentitlement"
-	"net/url"
 )
 
 func SubscriptionEntitlementsForSubscription(id string, params *subscriptionentitlement.SubscriptionEntitlementsForSubscriptionRequestParams) chargebee.RequestObj {
-	return chargebee.SendList("GET", fmt.Sprintf("/subscriptions/%v/subscription_entitlements", url.PathEscape(id)), params)
+	return chargebee.SendList("GET", fmt.Sprintf("/subscriptions/%v/subscription_entitlements", chargebee.IDEscape(id)), params)
 }
 func SetSubscriptionEntitlementAvailability(id string, params *subscriptionentitlement.SetSubscriptionEntitlementAvailabilityRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/subscription_entitlements/set_availability", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/subscription_entitlements/set_availability", chargebee.IDEscape(id)), params)
 }

--- a/actions/timemachine/time_machine.go
+++ b/actions/timemachine/time_machine.go
@@ -4,21 +4,21 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/timemachine"
 	timeMachineEnum "github.com/chargebee/chargebee-go/v3/models/timemachine/enum"
-	"time"
-	"net/url"
 )
 
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/time_machines/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/time_machines/%v", chargebee.IDEscape(id)), nil)
 }
 func StartAfresh(id string, params *timemachine.StartAfreshRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/time_machines/%v/start_afresh", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/time_machines/%v/start_afresh", chargebee.IDEscape(id)), params)
 }
 func TravelForward(id string, params *timemachine.TravelForwardRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/time_machines/%v/travel_forward", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/time_machines/%v/travel_forward", chargebee.IDEscape(id)), params)
 }
 func WaitForTimeTravelCompletion(tm timemachine.TimeMachine) (timemachine.TimeMachine, error) {
 	return WaitForTimeTravelCompletionWithEnv(tm, chargebee.DefaultConfig())

--- a/actions/transaction/transaction.go
+++ b/actions/transaction/transaction.go
@@ -2,38 +2,38 @@ package transaction
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/transaction"
-	"net/url"
 )
 
 func CreateAuthorization(params *transaction.CreateAuthorizationRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/transactions/create_authorization"), params)
 }
 func VoidTransaction(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/transactions/%v/void", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/transactions/%v/void", chargebee.IDEscape(id)), nil)
 }
 func RecordRefund(id string, params *transaction.RecordRefundRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/transactions/%v/record_refund", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/transactions/%v/record_refund", chargebee.IDEscape(id)), params)
 }
 func Refund(id string, params *transaction.RefundRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/transactions/%v/refund", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/transactions/%v/refund", chargebee.IDEscape(id)), params)
 }
 func List(params *transaction.ListRequestParams) chargebee.RequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/transactions"), params)
 }
 func TransactionsForCustomer(id string, params *transaction.TransactionsForCustomerRequestParams) chargebee.RequestObj {
-	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/transactions", url.PathEscape(id)), params)
+	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/transactions", chargebee.IDEscape(id)), params)
 }
 func TransactionsForSubscription(id string, params *transaction.TransactionsForSubscriptionRequestParams) chargebee.RequestObj {
-	return chargebee.SendList("GET", fmt.Sprintf("/subscriptions/%v/transactions", url.PathEscape(id)), params)
+	return chargebee.SendList("GET", fmt.Sprintf("/subscriptions/%v/transactions", chargebee.IDEscape(id)), params)
 }
 func PaymentsForInvoice(id string, params *transaction.PaymentsForInvoiceRequestParams) chargebee.RequestObj {
-	return chargebee.SendList("GET", fmt.Sprintf("/invoices/%v/payments", url.PathEscape(id)), params)
+	return chargebee.SendList("GET", fmt.Sprintf("/invoices/%v/payments", chargebee.IDEscape(id)), params)
 }
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/transactions/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/transactions/%v", chargebee.IDEscape(id)), nil)
 }
 func DeleteOfflineTransaction(id string, params *transaction.DeleteOfflineTransactionRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/transactions/%v/delete_offline_transaction", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/transactions/%v/delete_offline_transaction", chargebee.IDEscape(id)), params)
 }

--- a/actions/unbilledcharge/unbilled_charge.go
+++ b/actions/unbilledcharge/unbilled_charge.go
@@ -2,9 +2,9 @@ package unbilledcharge
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/unbilledcharge"
-	"net/url"
 )
 
 func CreateUnbilledCharge(params *unbilledcharge.CreateUnbilledChargeRequestParams) chargebee.RequestObj {
@@ -17,7 +17,7 @@ func InvoiceUnbilledCharges(params *unbilledcharge.InvoiceUnbilledChargesRequest
 	return chargebee.Send("POST", fmt.Sprintf("/unbilled_charges/invoice_unbilled_charges"), params)
 }
 func Delete(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/unbilled_charges/%v/delete", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/unbilled_charges/%v/delete", chargebee.IDEscape(id)), nil)
 }
 func List(params *unbilledcharge.ListRequestParams) chargebee.RequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/unbilled_charges"), params)

--- a/actions/usage/usage.go
+++ b/actions/usage/usage.go
@@ -2,19 +2,19 @@ package usage
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/usage"
-	"net/url"
 )
 
 func Create(id string, params *usage.CreateRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/usages", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/usages", chargebee.IDEscape(id)), params)
 }
 func Retrieve(id string, params *usage.RetrieveRequestParams) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/subscriptions/%v/usages", url.PathEscape(id)), params)
+	return chargebee.Send("GET", fmt.Sprintf("/subscriptions/%v/usages", chargebee.IDEscape(id)), params)
 }
 func Delete(id string, params *usage.DeleteRequestParams) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/delete_usage", url.PathEscape(id)), params)
+	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/delete_usage", chargebee.IDEscape(id)), params)
 }
 func List(params *usage.ListRequestParams) chargebee.RequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/usages"), params)

--- a/actions/virtualbankaccount/virtual_bank_account.go
+++ b/actions/virtualbankaccount/virtual_bank_account.go
@@ -2,9 +2,9 @@ package virtualbankaccount
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/virtualbankaccount"
-	"net/url"
 )
 
 func CreateUsingPermanentToken(params *virtualbankaccount.CreateUsingPermanentTokenRequestParams) chargebee.RequestObj {
@@ -14,14 +14,14 @@ func Create(params *virtualbankaccount.CreateRequestParams) chargebee.RequestObj
 	return chargebee.Send("POST", fmt.Sprintf("/virtual_bank_accounts"), params)
 }
 func Retrieve(id string) chargebee.RequestObj {
-	return chargebee.Send("GET", fmt.Sprintf("/virtual_bank_accounts/%v", url.PathEscape(id)), nil)
+	return chargebee.Send("GET", fmt.Sprintf("/virtual_bank_accounts/%v", chargebee.IDEscape(id)), nil)
 }
 func List(params *virtualbankaccount.ListRequestParams) chargebee.RequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/virtual_bank_accounts"), params)
 }
 func Delete(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/virtual_bank_accounts/%v/delete", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/virtual_bank_accounts/%v/delete", chargebee.IDEscape(id)), nil)
 }
 func DeleteLocal(id string) chargebee.RequestObj {
-	return chargebee.Send("POST", fmt.Sprintf("/virtual_bank_accounts/%v/delete_local", url.PathEscape(id)), nil)
+	return chargebee.Send("POST", fmt.Sprintf("/virtual_bank_accounts/%v/delete_local", chargebee.IDEscape(id)), nil)
 }

--- a/util.go
+++ b/util.go
@@ -20,7 +20,7 @@ func getParamTypes(params interface{}) map[string]string {
 	return m
 }
 
-//SerializeParams is to used to serialize the inputParams request .
+// SerializeParams is to used to serialize the inputParams request .
 // Eg : Customer : { FirstName : "John" } is serialized as "customer[first_name]" : "John".
 func SerializeParams(params interface{}) *url.Values {
 	queryParams, err := json.Marshal(params)
@@ -113,7 +113,7 @@ func parseArray(anArray []interface{}, serParams map[string]interface{}, prefix 
 	}
 }
 
-//SerializeListParams is to used to serialize the inputParams of list request.
+// SerializeListParams is to used to serialize the inputParams of list request.
 func SerializeListParams(params interface{}) *url.Values {
 	queryParams, err := json.Marshal(params)
 	if err != nil {
@@ -176,7 +176,7 @@ func camelCase(str string) string {
 	return res
 }
 
-//customFieldExtraction is used extract the customFields from response and append it in Result struct
+// customFieldExtraction is used extract the customFields from response and append it in Result struct
 func customFieldExtraction(v interface{}, resJSON []byte) {
 	switch v.(type) {
 	case *Result:
@@ -258,12 +258,12 @@ func prepareResultListCF(resbody []byte, v interface{}) {
 	}
 }
 
-//Bool returns a pointer to the bool value passed.
+// Bool returns a pointer to the bool value passed.
 func Bool(val bool) *bool {
 	return &val
 }
 
-//BoolValue returns the value of the bool pointer passed or false if the pointer is nil.
+// BoolValue returns the value of the bool pointer passed or false if the pointer is nil.
 func BoolValue(val *bool) bool {
 	if val != nil {
 		return *val
@@ -271,12 +271,12 @@ func BoolValue(val *bool) bool {
 	return false
 }
 
-//Int32 returns a pointer to the int32 value passed.
+// Int32 returns a pointer to the int32 value passed.
 func Int32(val int32) *int32 {
 	return &val
 }
 
-//Int32Value returns the value of the int32 pointer passed or 0 if the pointer is nil.
+// Int32Value returns the value of the int32 pointer passed or 0 if the pointer is nil.
 func Int32Value(val *int32) int32 {
 	if val != nil {
 		return *val
@@ -284,12 +284,12 @@ func Int32Value(val *int32) int32 {
 	return 0
 }
 
-//Int64 returns a pointer to the int64 value passed.
+// Int64 returns a pointer to the int64 value passed.
 func Int64(val int64) *int64 {
 	return &val
 }
 
-//Int64Value returns the value of the int64 pointer passed or 0 if the pointer is nil.
+// Int64Value returns the value of the int64 pointer passed or 0 if the pointer is nil.
 func Int64Value(val *int64) int64 {
 	if val != nil {
 		return *val
@@ -297,15 +297,23 @@ func Int64Value(val *int64) int64 {
 	return 0
 }
 
-//Float64 returns a pointer to the float64 value passed.
+// Float64 returns a pointer to the float64 value passed.
 func Float64(val float64) *float64 {
 	return &val
 }
 
-//Float64Value returns the value of the float64 pointer passed or 0 if the pointer is nil.
+// Float64Value returns the value of the float64 pointer passed or 0 if the pointer is nil.
 func Float64Value(val *float64) float64 {
 	if val != nil {
 		return *val
 	}
 	return 0
+}
+
+// IDEscape escapes the string so it can be safely placed inside a URL path segment,
+// replacing special characters (excluding /) with %XX sequences as needed.
+// This is needed as Chargebee IDs can contain forward slashes (/) in the ID and
+// they need to be retained in the URL for the API to work.
+func IDEscape(s string) string {
+	return strings.ReplaceAll(url.PathEscape(s), "%2F", "/")
 }


### PR DESCRIPTION
### Description

Fix: Retain forward slashes in Chargebee IDs

If the Chargebee ID contains a forward slash ("/"), this should not be URL escaped in the query as Chargebee will not be able to interpret it. Thus, we retain any forward slashes in IDs when querying the API.

When querying, this does not work:
```
curl  https://acme.chargebee.com/api/v2/subscriptions/ACME%20GmbH%2FCompany%20GmbH/renewal_estimate
```

This works, however:
```
curl  https://acme.chargebee.com/api/v2/subscriptions/ACME%20GmbH/Company%20GmbH/renewal_estimate
```