### PR TITLE
Segeration between ListRequestObj & RequestObj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### New Enhancement:
 * Introduced proper separation between `RequestObj` and `ListRequestObj` for better type safety and API clarity.
-* Added clean type aliases: `Request` for `RequestObj` and `ListRequest` for `ListRequestObj`.
+* Added type aliases `Request` and `ListRequest`
 * Updated all methods to use the new aliases while maintaining full backwards compatibility.
 
 ### v3.36.0 (2025-07-18) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### v3.37.0 (2025-07-27)
+***
+
+### New Enhancement:
+* Introduced proper separation between `RequestObj` and `ListRequestObj` for better type safety and API clarity.
+* Added clean type aliases: `Request` for `RequestObj` and `ListRequest` for `ListRequestObj`.
+* Updated all methods to use the new aliases while maintaining full backwards compatibility.
+
 ### v3.36.0 (2025-07-18) 
 * * * 
 

--- a/actions/addon/addon.go
+++ b/actions/addon/addon.go
@@ -13,7 +13,7 @@ func Create(params *addon.CreateRequestParams) chargebee.RequestObj {
 func Update(id string, params *addon.UpdateRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/addons/%v", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func List(params *addon.ListRequestParams) chargebee.RequestObj {
+func List(params *addon.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/addons"), params)
 }
 func Retrieve(id string) chargebee.RequestObj {

--- a/actions/addon/addon.go
+++ b/actions/addon/addon.go
@@ -7,24 +7,24 @@ import (
 	"net/url"
 )
 
-func Create(params *addon.CreateRequestParams) chargebee.RequestObj {
+func Create(params *addon.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/addons"), params).SetIdempotency(true)
 }
-func Update(id string, params *addon.UpdateRequestParams) chargebee.RequestObj {
+func Update(id string, params *addon.UpdateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/addons/%v", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func List(params *addon.ListRequestParams) chargebee.ListRequestObj {
+func List(params *addon.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/addons"), params)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/addons/%v", url.PathEscape(id)), nil)
 }
-func Delete(id string) chargebee.RequestObj {
+func Delete(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/addons/%v/delete", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func Copy(params *addon.CopyRequestParams) chargebee.RequestObj {
+func Copy(params *addon.CopyRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/addons/copy"), params).SetIdempotency(true)
 }
-func Unarchive(id string) chargebee.RequestObj {
+func Unarchive(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/addons/%v/unarchive", url.PathEscape(id)), nil).SetIdempotency(true)
 }

--- a/actions/address/address.go
+++ b/actions/address/address.go
@@ -6,9 +6,9 @@ import (
 	"github.com/chargebee/chargebee-go/v3/models/address"
 )
 
-func Retrieve(params *address.RetrieveRequestParams) chargebee.RequestObj {
+func Retrieve(params *address.RetrieveRequestParams) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/addresses"), params)
 }
-func Update(params *address.UpdateRequestParams) chargebee.RequestObj {
+func Update(params *address.UpdateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/addresses"), params).SetIdempotency(true)
 }

--- a/actions/attacheditem/attached_item.go
+++ b/actions/attacheditem/attached_item.go
@@ -19,6 +19,6 @@ func Retrieve(id string, params *attacheditem.RetrieveRequestParams) chargebee.R
 func Delete(id string, params *attacheditem.DeleteRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/attached_items/%v/delete", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func List(id string, params *attacheditem.ListRequestParams) chargebee.RequestObj {
+func List(id string, params *attacheditem.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/items/%v/attached_items", url.PathEscape(id)), params)
 }

--- a/actions/attacheditem/attached_item.go
+++ b/actions/attacheditem/attached_item.go
@@ -7,18 +7,18 @@ import (
 	"net/url"
 )
 
-func Create(id string, params *attacheditem.CreateRequestParams) chargebee.RequestObj {
+func Create(id string, params *attacheditem.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/items/%v/attached_items", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Update(id string, params *attacheditem.UpdateRequestParams) chargebee.RequestObj {
+func Update(id string, params *attacheditem.UpdateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/attached_items/%v", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Retrieve(id string, params *attacheditem.RetrieveRequestParams) chargebee.RequestObj {
+func Retrieve(id string, params *attacheditem.RetrieveRequestParams) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/attached_items/%v", url.PathEscape(id)), params)
 }
-func Delete(id string, params *attacheditem.DeleteRequestParams) chargebee.RequestObj {
+func Delete(id string, params *attacheditem.DeleteRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/attached_items/%v/delete", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func List(id string, params *attacheditem.ListRequestParams) chargebee.ListRequestObj {
+func List(id string, params *attacheditem.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/items/%v/attached_items", url.PathEscape(id)), params)
 }

--- a/actions/businessentity/business_entity.go
+++ b/actions/businessentity/business_entity.go
@@ -9,6 +9,6 @@ import (
 func CreateTransfers(params *businessentity.CreateTransfersRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/business_entities/transfers"), params).SetIdempotency(true)
 }
-func GetTransfers(params *businessentity.GetTransfersRequestParams) chargebee.RequestObj {
+func GetTransfers(params *businessentity.GetTransfersRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/business_entities/transfers"), params)
 }

--- a/actions/businessentity/business_entity.go
+++ b/actions/businessentity/business_entity.go
@@ -6,9 +6,9 @@ import (
 	"github.com/chargebee/chargebee-go/v3/models/businessentity"
 )
 
-func CreateTransfers(params *businessentity.CreateTransfersRequestParams) chargebee.RequestObj {
+func CreateTransfers(params *businessentity.CreateTransfersRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/business_entities/transfers"), params).SetIdempotency(true)
 }
-func GetTransfers(params *businessentity.GetTransfersRequestParams) chargebee.ListRequestObj {
+func GetTransfers(params *businessentity.GetTransfersRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/business_entities/transfers"), params)
 }

--- a/actions/card/card.go
+++ b/actions/card/card.go
@@ -7,18 +7,18 @@ import (
 	"net/url"
 )
 
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/cards/%v", url.PathEscape(id)), nil)
 }
-func UpdateCardForCustomer(id string, params *card.UpdateCardForCustomerRequestParams) chargebee.RequestObj {
+func UpdateCardForCustomer(id string, params *card.UpdateCardForCustomerRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/credit_card", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func SwitchGatewayForCustomer(id string, params *card.SwitchGatewayForCustomerRequestParams) chargebee.RequestObj {
+func SwitchGatewayForCustomer(id string, params *card.SwitchGatewayForCustomerRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/switch_gateway", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func CopyCardForCustomer(id string, params *card.CopyCardForCustomerRequestParams) chargebee.RequestObj {
+func CopyCardForCustomer(id string, params *card.CopyCardForCustomerRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/copy_card", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func DeleteCardForCustomer(id string) chargebee.RequestObj {
+func DeleteCardForCustomer(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/delete_card", url.PathEscape(id)), nil).SetIdempotency(true)
 }

--- a/actions/comment/comment.go
+++ b/actions/comment/comment.go
@@ -13,7 +13,7 @@ func Create(params *comment.CreateRequestParams) chargebee.RequestObj {
 func Retrieve(id string) chargebee.RequestObj {
 	return chargebee.Send("GET", fmt.Sprintf("/comments/%v", url.PathEscape(id)), nil)
 }
-func List(params *comment.ListRequestParams) chargebee.RequestObj {
+func List(params *comment.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/comments"), params)
 }
 func Delete(id string) chargebee.RequestObj {

--- a/actions/comment/comment.go
+++ b/actions/comment/comment.go
@@ -7,15 +7,15 @@ import (
 	"net/url"
 )
 
-func Create(params *comment.CreateRequestParams) chargebee.RequestObj {
+func Create(params *comment.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/comments"), params).SetIdempotency(true)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/comments/%v", url.PathEscape(id)), nil)
 }
-func List(params *comment.ListRequestParams) chargebee.ListRequestObj {
+func List(params *comment.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/comments"), params)
 }
-func Delete(id string) chargebee.RequestObj {
+func Delete(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/comments/%v/delete", url.PathEscape(id)), nil).SetIdempotency(true)
 }

--- a/actions/configuration/configuration.go
+++ b/actions/configuration/configuration.go
@@ -5,6 +5,6 @@ import (
 	"github.com/chargebee/chargebee-go/v3"
 )
 
-func List() chargebee.RequestObj {
+func List() chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/configurations"), nil)
 }

--- a/actions/coupon/coupon.go
+++ b/actions/coupon/coupon.go
@@ -16,7 +16,7 @@ func CreateForItems(params *coupon.CreateForItemsRequestParams) chargebee.Reques
 func UpdateForItems(id string, params *coupon.UpdateForItemsRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/coupons/%v/update_for_items", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func List(params *coupon.ListRequestParams) chargebee.RequestObj {
+func List(params *coupon.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/coupons"), params)
 }
 func Retrieve(id string) chargebee.RequestObj {

--- a/actions/coupon/coupon.go
+++ b/actions/coupon/coupon.go
@@ -7,30 +7,30 @@ import (
 	"net/url"
 )
 
-func Create(params *coupon.CreateRequestParams) chargebee.RequestObj {
+func Create(params *coupon.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/coupons"), params).SetIdempotency(true)
 }
-func CreateForItems(params *coupon.CreateForItemsRequestParams) chargebee.RequestObj {
+func CreateForItems(params *coupon.CreateForItemsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/coupons/create_for_items"), params).SetIdempotency(true)
 }
-func UpdateForItems(id string, params *coupon.UpdateForItemsRequestParams) chargebee.RequestObj {
+func UpdateForItems(id string, params *coupon.UpdateForItemsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/coupons/%v/update_for_items", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func List(params *coupon.ListRequestParams) chargebee.ListRequestObj {
+func List(params *coupon.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/coupons"), params)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/coupons/%v", url.PathEscape(id)), nil)
 }
-func Update(id string, params *coupon.UpdateRequestParams) chargebee.RequestObj {
+func Update(id string, params *coupon.UpdateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/coupons/%v", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Delete(id string) chargebee.RequestObj {
+func Delete(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/coupons/%v/delete", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func Copy(params *coupon.CopyRequestParams) chargebee.RequestObj {
+func Copy(params *coupon.CopyRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/coupons/copy"), params).SetIdempotency(true)
 }
-func Unarchive(id string) chargebee.RequestObj {
+func Unarchive(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/coupons/%v/unarchive", url.PathEscape(id)), nil).SetIdempotency(true)
 }

--- a/actions/couponcode/coupon_code.go
+++ b/actions/couponcode/coupon_code.go
@@ -13,7 +13,7 @@ func Create(params *couponcode.CreateRequestParams) chargebee.RequestObj {
 func Retrieve(id string) chargebee.RequestObj {
 	return chargebee.Send("GET", fmt.Sprintf("/coupon_codes/%v", url.PathEscape(id)), nil)
 }
-func List(params *couponcode.ListRequestParams) chargebee.RequestObj {
+func List(params *couponcode.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/coupon_codes"), params)
 }
 func Archive(id string) chargebee.RequestObj {

--- a/actions/couponcode/coupon_code.go
+++ b/actions/couponcode/coupon_code.go
@@ -7,15 +7,15 @@ import (
 	"net/url"
 )
 
-func Create(params *couponcode.CreateRequestParams) chargebee.RequestObj {
+func Create(params *couponcode.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/coupon_codes"), params).SetIdempotency(true)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/coupon_codes/%v", url.PathEscape(id)), nil)
 }
-func List(params *couponcode.ListRequestParams) chargebee.ListRequestObj {
+func List(params *couponcode.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/coupon_codes"), params)
 }
-func Archive(id string) chargebee.RequestObj {
+func Archive(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/coupon_codes/%v/archive", url.PathEscape(id)), nil).SetIdempotency(true)
 }

--- a/actions/couponset/coupon_set.go
+++ b/actions/couponset/coupon_set.go
@@ -13,7 +13,7 @@ func Create(params *couponset.CreateRequestParams) chargebee.RequestObj {
 func AddCouponCodes(id string, params *couponset.AddCouponCodesRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/coupon_sets/%v/add_coupon_codes", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func List(params *couponset.ListRequestParams) chargebee.RequestObj {
+func List(params *couponset.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/coupon_sets"), params)
 }
 func Retrieve(id string) chargebee.RequestObj {

--- a/actions/couponset/coupon_set.go
+++ b/actions/couponset/coupon_set.go
@@ -7,24 +7,24 @@ import (
 	"net/url"
 )
 
-func Create(params *couponset.CreateRequestParams) chargebee.RequestObj {
+func Create(params *couponset.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/coupon_sets"), params).SetIdempotency(true)
 }
-func AddCouponCodes(id string, params *couponset.AddCouponCodesRequestParams) chargebee.RequestObj {
+func AddCouponCodes(id string, params *couponset.AddCouponCodesRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/coupon_sets/%v/add_coupon_codes", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func List(params *couponset.ListRequestParams) chargebee.ListRequestObj {
+func List(params *couponset.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/coupon_sets"), params)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/coupon_sets/%v", url.PathEscape(id)), nil)
 }
-func Update(id string, params *couponset.UpdateRequestParams) chargebee.RequestObj {
+func Update(id string, params *couponset.UpdateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/coupon_sets/%v/update", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Delete(id string) chargebee.RequestObj {
+func Delete(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/coupon_sets/%v/delete", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func DeleteUnusedCouponCodes(id string) chargebee.RequestObj {
+func DeleteUnusedCouponCodes(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/coupon_sets/%v/delete_unused_coupon_codes", url.PathEscape(id)), nil).SetIdempotency(true)
 }

--- a/actions/creditnote/credit_note.go
+++ b/actions/creditnote/credit_note.go
@@ -28,10 +28,10 @@ func RecordRefund(id string, params *creditnote.RecordRefundRequestParams) charg
 func VoidCreditNote(id string, params *creditnote.VoidCreditNoteRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/credit_notes/%v/void", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func List(params *creditnote.ListRequestParams) chargebee.RequestObj {
+func List(params *creditnote.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/credit_notes"), params)
 }
-func CreditNotesForCustomer(id string, params *creditnote.CreditNotesForCustomerRequestParams) chargebee.RequestObj {
+func CreditNotesForCustomer(id string, params *creditnote.CreditNotesForCustomerRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/credit_notes", url.PathEscape(id)), params)
 }
 func Delete(id string, params *creditnote.DeleteRequestParams) chargebee.RequestObj {

--- a/actions/creditnote/credit_note.go
+++ b/actions/creditnote/credit_note.go
@@ -7,45 +7,45 @@ import (
 	"net/url"
 )
 
-func Create(params *creditnote.CreateRequestParams) chargebee.RequestObj {
+func Create(params *creditnote.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/credit_notes"), params).SetIdempotency(true)
 }
-func Retrieve(id string, params *creditnote.RetrieveRequestParams) chargebee.RequestObj {
+func Retrieve(id string, params *creditnote.RetrieveRequestParams) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/credit_notes/%v", url.PathEscape(id)), params)
 }
-func Pdf(id string, params *creditnote.PdfRequestParams) chargebee.RequestObj {
+func Pdf(id string, params *creditnote.PdfRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/credit_notes/%v/pdf", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func DownloadEinvoice(id string) chargebee.RequestObj {
+func DownloadEinvoice(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/credit_notes/%v/download_einvoice", url.PathEscape(id)), nil)
 }
-func Refund(id string, params *creditnote.RefundRequestParams) chargebee.RequestObj {
+func Refund(id string, params *creditnote.RefundRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/credit_notes/%v/refund", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func RecordRefund(id string, params *creditnote.RecordRefundRequestParams) chargebee.RequestObj {
+func RecordRefund(id string, params *creditnote.RecordRefundRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/credit_notes/%v/record_refund", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func VoidCreditNote(id string, params *creditnote.VoidCreditNoteRequestParams) chargebee.RequestObj {
+func VoidCreditNote(id string, params *creditnote.VoidCreditNoteRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/credit_notes/%v/void", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func List(params *creditnote.ListRequestParams) chargebee.ListRequestObj {
+func List(params *creditnote.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/credit_notes"), params)
 }
-func CreditNotesForCustomer(id string, params *creditnote.CreditNotesForCustomerRequestParams) chargebee.ListRequestObj {
+func CreditNotesForCustomer(id string, params *creditnote.CreditNotesForCustomerRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/credit_notes", url.PathEscape(id)), params)
 }
-func Delete(id string, params *creditnote.DeleteRequestParams) chargebee.RequestObj {
+func Delete(id string, params *creditnote.DeleteRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/credit_notes/%v/delete", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func RemoveTaxWithheldRefund(id string, params *creditnote.RemoveTaxWithheldRefundRequestParams) chargebee.RequestObj {
+func RemoveTaxWithheldRefund(id string, params *creditnote.RemoveTaxWithheldRefundRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/credit_notes/%v/remove_tax_withheld_refund", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func ResendEinvoice(id string) chargebee.RequestObj {
+func ResendEinvoice(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/credit_notes/%v/resend_einvoice", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func SendEinvoice(id string) chargebee.RequestObj {
+func SendEinvoice(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/credit_notes/%v/send_einvoice", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func ImportCreditNote(params *creditnote.ImportCreditNoteRequestParams) chargebee.RequestObj {
+func ImportCreditNote(params *creditnote.ImportCreditNoteRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/credit_notes/import_credit_note"), params).SetIdempotency(true)
 }

--- a/actions/csvtaxrule/csv_tax_rule.go
+++ b/actions/csvtaxrule/csv_tax_rule.go
@@ -2,10 +2,11 @@ package csvtaxrule
 
 import (
 	"fmt"
+
 	"github.com/chargebee/chargebee-go/v3"
 	"github.com/chargebee/chargebee-go/v3/models/csvtaxrule"
 )
 
-func Create(params *csvtaxrule.CreateRequestParams) chargebee.RequestObj {
+func Create(params *csvtaxrule.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/csv_tax_rules"), params)
 }

--- a/actions/currency/currency.go
+++ b/actions/currency/currency.go
@@ -7,21 +7,21 @@ import (
 	"net/url"
 )
 
-func List() chargebee.RequestObj {
+func List() chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/currencies/list"), nil)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/currencies/%v", url.PathEscape(id)), nil)
 }
-func Create(params *currency.CreateRequestParams) chargebee.RequestObj {
+func Create(params *currency.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/currencies"), params).SetIdempotency(true)
 }
-func Update(id string, params *currency.UpdateRequestParams) chargebee.RequestObj {
+func Update(id string, params *currency.UpdateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/currencies/%v", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func AddSchedule(id string, params *currency.AddScheduleRequestParams) chargebee.RequestObj {
+func AddSchedule(id string, params *currency.AddScheduleRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/currencies/%v/add_schedule", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func RemoveSchedule(id string) chargebee.RequestObj {
+func RemoveSchedule(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/currencies/%v/remove_schedule", url.PathEscape(id)), nil).SetIdempotency(true)
 }

--- a/actions/customer/customer.go
+++ b/actions/customer/customer.go
@@ -7,81 +7,81 @@ import (
 	"net/url"
 )
 
-func Create(params *customer.CreateRequestParams) chargebee.RequestObj {
+func Create(params *customer.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers"), params).SetIdempotency(true)
 }
-func List(params *customer.ListRequestParams) chargebee.ListRequestObj {
+func List(params *customer.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/customers"), params)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/customers/%v", url.PathEscape(id)), nil)
 }
-func Update(id string, params *customer.UpdateRequestParams) chargebee.RequestObj {
+func Update(id string, params *customer.UpdateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func UpdatePaymentMethod(id string, params *customer.UpdatePaymentMethodRequestParams) chargebee.RequestObj {
+func UpdatePaymentMethod(id string, params *customer.UpdatePaymentMethodRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/update_payment_method", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func UpdateBillingInfo(id string, params *customer.UpdateBillingInfoRequestParams) chargebee.RequestObj {
+func UpdateBillingInfo(id string, params *customer.UpdateBillingInfoRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/update_billing_info", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func ContactsForCustomer(id string, params *customer.ContactsForCustomerRequestParams) chargebee.ListRequestObj {
+func ContactsForCustomer(id string, params *customer.ContactsForCustomerRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/contacts", url.PathEscape(id)), params)
 }
-func AssignPaymentRole(id string, params *customer.AssignPaymentRoleRequestParams) chargebee.RequestObj {
+func AssignPaymentRole(id string, params *customer.AssignPaymentRoleRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/assign_payment_role", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func AddContact(id string, params *customer.AddContactRequestParams) chargebee.RequestObj {
+func AddContact(id string, params *customer.AddContactRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/add_contact", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func UpdateContact(id string, params *customer.UpdateContactRequestParams) chargebee.RequestObj {
+func UpdateContact(id string, params *customer.UpdateContactRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/update_contact", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func DeleteContact(id string, params *customer.DeleteContactRequestParams) chargebee.RequestObj {
+func DeleteContact(id string, params *customer.DeleteContactRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/delete_contact", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func AddPromotionalCredits(id string, params *customer.AddPromotionalCreditsRequestParams) chargebee.RequestObj {
+func AddPromotionalCredits(id string, params *customer.AddPromotionalCreditsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/add_promotional_credits", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func DeductPromotionalCredits(id string, params *customer.DeductPromotionalCreditsRequestParams) chargebee.RequestObj {
+func DeductPromotionalCredits(id string, params *customer.DeductPromotionalCreditsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/deduct_promotional_credits", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func SetPromotionalCredits(id string, params *customer.SetPromotionalCreditsRequestParams) chargebee.RequestObj {
+func SetPromotionalCredits(id string, params *customer.SetPromotionalCreditsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/set_promotional_credits", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func RecordExcessPayment(id string, params *customer.RecordExcessPaymentRequestParams) chargebee.RequestObj {
+func RecordExcessPayment(id string, params *customer.RecordExcessPaymentRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/record_excess_payment", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func CollectPayment(id string, params *customer.CollectPaymentRequestParams) chargebee.RequestObj {
+func CollectPayment(id string, params *customer.CollectPaymentRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/collect_payment", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Delete(id string, params *customer.DeleteRequestParams) chargebee.RequestObj {
+func Delete(id string, params *customer.DeleteRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/delete", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Move(params *customer.MoveRequestParams) chargebee.RequestObj {
+func Move(params *customer.MoveRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/move"), params).SetIdempotency(true)
 }
-func ChangeBillingDate(id string, params *customer.ChangeBillingDateRequestParams) chargebee.RequestObj {
+func ChangeBillingDate(id string, params *customer.ChangeBillingDateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/change_billing_date", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Merge(params *customer.MergeRequestParams) chargebee.RequestObj {
+func Merge(params *customer.MergeRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/merge"), params).SetIdempotency(true)
 }
-func ClearPersonalData(id string) chargebee.RequestObj {
+func ClearPersonalData(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/clear_personal_data", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func Relationships(id string, params *customer.RelationshipsRequestParams) chargebee.RequestObj {
+func Relationships(id string, params *customer.RelationshipsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/relationships", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func DeleteRelationship(id string) chargebee.RequestObj {
+func DeleteRelationship(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/delete_relationship", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func Hierarchy(id string, params *customer.HierarchyRequestParams) chargebee.RequestObj {
+func Hierarchy(id string, params *customer.HierarchyRequestParams) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/customers/%v/hierarchy", url.PathEscape(id)), params)
 }
-func ListHierarchyDetail(id string, params *customer.ListHierarchyDetailRequestParams) chargebee.ListRequestObj {
+func ListHierarchyDetail(id string, params *customer.ListHierarchyDetailRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/hierarchy_detail", url.PathEscape(id)), params)
 }
-func UpdateHierarchySettings(id string, params *customer.UpdateHierarchySettingsRequestParams) chargebee.RequestObj {
+func UpdateHierarchySettings(id string, params *customer.UpdateHierarchySettingsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/update_hierarchy_settings", url.PathEscape(id)), params).SetIdempotency(true)
 }

--- a/actions/customer/customer.go
+++ b/actions/customer/customer.go
@@ -10,7 +10,7 @@ import (
 func Create(params *customer.CreateRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/customers"), params).SetIdempotency(true)
 }
-func List(params *customer.ListRequestParams) chargebee.RequestObj {
+func List(params *customer.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/customers"), params)
 }
 func Retrieve(id string) chargebee.RequestObj {
@@ -25,7 +25,7 @@ func UpdatePaymentMethod(id string, params *customer.UpdatePaymentMethodRequestP
 func UpdateBillingInfo(id string, params *customer.UpdateBillingInfoRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/update_billing_info", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func ContactsForCustomer(id string, params *customer.ContactsForCustomerRequestParams) chargebee.RequestObj {
+func ContactsForCustomer(id string, params *customer.ContactsForCustomerRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/contacts", url.PathEscape(id)), params)
 }
 func AssignPaymentRole(id string, params *customer.AssignPaymentRoleRequestParams) chargebee.RequestObj {
@@ -79,7 +79,7 @@ func DeleteRelationship(id string) chargebee.RequestObj {
 func Hierarchy(id string, params *customer.HierarchyRequestParams) chargebee.RequestObj {
 	return chargebee.Send("GET", fmt.Sprintf("/customers/%v/hierarchy", url.PathEscape(id)), params)
 }
-func ListHierarchyDetail(id string, params *customer.ListHierarchyDetailRequestParams) chargebee.RequestObj {
+func ListHierarchyDetail(id string, params *customer.ListHierarchyDetailRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/hierarchy_detail", url.PathEscape(id)), params)
 }
 func UpdateHierarchySettings(id string, params *customer.UpdateHierarchySettingsRequestParams) chargebee.RequestObj {

--- a/actions/customerentitlement/customer_entitlement.go
+++ b/actions/customerentitlement/customer_entitlement.go
@@ -7,6 +7,6 @@ import (
 	"net/url"
 )
 
-func EntitlementsForCustomer(id string, params *customerentitlement.EntitlementsForCustomerRequestParams) chargebee.RequestObj {
+func EntitlementsForCustomer(id string, params *customerentitlement.EntitlementsForCustomerRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/customer_entitlements", url.PathEscape(id)), params)
 }

--- a/actions/customerentitlement/customer_entitlement.go
+++ b/actions/customerentitlement/customer_entitlement.go
@@ -7,6 +7,6 @@ import (
 	"net/url"
 )
 
-func EntitlementsForCustomer(id string, params *customerentitlement.EntitlementsForCustomerRequestParams) chargebee.ListRequestObj {
+func EntitlementsForCustomer(id string, params *customerentitlement.EntitlementsForCustomerRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/customer_entitlements", url.PathEscape(id)), params)
 }

--- a/actions/differentialprice/differential_price.go
+++ b/actions/differentialprice/differential_price.go
@@ -7,18 +7,18 @@ import (
 	"net/url"
 )
 
-func Create(id string, params *differentialprice.CreateRequestParams) chargebee.RequestObj {
+func Create(id string, params *differentialprice.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/item_prices/%v/differential_prices", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Retrieve(id string, params *differentialprice.RetrieveRequestParams) chargebee.RequestObj {
+func Retrieve(id string, params *differentialprice.RetrieveRequestParams) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/differential_prices/%v", url.PathEscape(id)), params)
 }
-func Update(id string, params *differentialprice.UpdateRequestParams) chargebee.RequestObj {
+func Update(id string, params *differentialprice.UpdateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/differential_prices/%v", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Delete(id string, params *differentialprice.DeleteRequestParams) chargebee.RequestObj {
+func Delete(id string, params *differentialprice.DeleteRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/differential_prices/%v/delete", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func List(params *differentialprice.ListRequestParams) chargebee.ListRequestObj {
+func List(params *differentialprice.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/differential_prices"), params)
 }

--- a/actions/differentialprice/differential_price.go
+++ b/actions/differentialprice/differential_price.go
@@ -19,6 +19,6 @@ func Update(id string, params *differentialprice.UpdateRequestParams) chargebee.
 func Delete(id string, params *differentialprice.DeleteRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/differential_prices/%v/delete", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func List(params *differentialprice.ListRequestParams) chargebee.RequestObj {
+func List(params *differentialprice.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/differential_prices"), params)
 }

--- a/actions/entitlement/entitlement.go
+++ b/actions/entitlement/entitlement.go
@@ -6,9 +6,9 @@ import (
 	"github.com/chargebee/chargebee-go/v3/models/entitlement"
 )
 
-func List(params *entitlement.ListRequestParams) chargebee.ListRequestObj {
+func List(params *entitlement.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/entitlements"), params)
 }
-func Create(params *entitlement.CreateRequestParams) chargebee.RequestObj {
+func Create(params *entitlement.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/entitlements"), params).SetIdempotency(true)
 }

--- a/actions/entitlement/entitlement.go
+++ b/actions/entitlement/entitlement.go
@@ -6,7 +6,7 @@ import (
 	"github.com/chargebee/chargebee-go/v3/models/entitlement"
 )
 
-func List(params *entitlement.ListRequestParams) chargebee.RequestObj {
+func List(params *entitlement.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/entitlements"), params)
 }
 func Create(params *entitlement.CreateRequestParams) chargebee.RequestObj {

--- a/actions/entitlementoverride/entitlement_override.go
+++ b/actions/entitlementoverride/entitlement_override.go
@@ -10,6 +10,6 @@ import (
 func AddEntitlementOverrideForSubscription(id string, params *entitlementoverride.AddEntitlementOverrideForSubscriptionRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/entitlement_overrides", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func ListEntitlementOverrideForSubscription(id string, params *entitlementoverride.ListEntitlementOverrideForSubscriptionRequestParams) chargebee.RequestObj {
+func ListEntitlementOverrideForSubscription(id string, params *entitlementoverride.ListEntitlementOverrideForSubscriptionRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/subscriptions/%v/entitlement_overrides", url.PathEscape(id)), params)
 }

--- a/actions/entitlementoverride/entitlement_override.go
+++ b/actions/entitlementoverride/entitlement_override.go
@@ -7,9 +7,9 @@ import (
 	"net/url"
 )
 
-func AddEntitlementOverrideForSubscription(id string, params *entitlementoverride.AddEntitlementOverrideForSubscriptionRequestParams) chargebee.RequestObj {
+func AddEntitlementOverrideForSubscription(id string, params *entitlementoverride.AddEntitlementOverrideForSubscriptionRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/entitlement_overrides", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func ListEntitlementOverrideForSubscription(id string, params *entitlementoverride.ListEntitlementOverrideForSubscriptionRequestParams) chargebee.ListRequestObj {
+func ListEntitlementOverrideForSubscription(id string, params *entitlementoverride.ListEntitlementOverrideForSubscriptionRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/subscriptions/%v/entitlement_overrides", url.PathEscape(id)), params)
 }

--- a/actions/estimate/estimate.go
+++ b/actions/estimate/estimate.go
@@ -7,63 +7,63 @@ import (
 	"net/url"
 )
 
-func CreateSubscription(params *estimate.CreateSubscriptionRequestParams) chargebee.RequestObj {
+func CreateSubscription(params *estimate.CreateSubscriptionRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/estimates/create_subscription"), params)
 }
-func CreateSubItemEstimate(params *estimate.CreateSubItemEstimateRequestParams) chargebee.RequestObj {
+func CreateSubItemEstimate(params *estimate.CreateSubItemEstimateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/estimates/create_subscription_for_items"), params)
 }
-func CreateSubForCustomerEstimate(id string, params *estimate.CreateSubForCustomerEstimateRequestParams) chargebee.RequestObj {
+func CreateSubForCustomerEstimate(id string, params *estimate.CreateSubForCustomerEstimateRequestParams) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/customers/%v/create_subscription_estimate", url.PathEscape(id)), params)
 }
-func CreateSubItemForCustomerEstimate(id string, params *estimate.CreateSubItemForCustomerEstimateRequestParams) chargebee.RequestObj {
+func CreateSubItemForCustomerEstimate(id string, params *estimate.CreateSubItemForCustomerEstimateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/create_subscription_for_items_estimate", url.PathEscape(id)), params)
 }
-func UpdateSubscription(params *estimate.UpdateSubscriptionRequestParams) chargebee.RequestObj {
+func UpdateSubscription(params *estimate.UpdateSubscriptionRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/estimates/update_subscription"), params)
 }
-func UpdateSubscriptionForItems(params *estimate.UpdateSubscriptionForItemsRequestParams) chargebee.RequestObj {
+func UpdateSubscriptionForItems(params *estimate.UpdateSubscriptionForItemsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/estimates/update_subscription_for_items"), params)
 }
-func RenewalEstimate(id string, params *estimate.RenewalEstimateRequestParams) chargebee.RequestObj {
+func RenewalEstimate(id string, params *estimate.RenewalEstimateRequestParams) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/subscriptions/%v/renewal_estimate", url.PathEscape(id)), params)
 }
-func AdvanceInvoiceEstimate(id string, params *estimate.AdvanceInvoiceEstimateRequestParams) chargebee.RequestObj {
+func AdvanceInvoiceEstimate(id string, params *estimate.AdvanceInvoiceEstimateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/advance_invoice_estimate", url.PathEscape(id)), params)
 }
-func RegenerateInvoiceEstimate(id string, params *estimate.RegenerateInvoiceEstimateRequestParams) chargebee.RequestObj {
+func RegenerateInvoiceEstimate(id string, params *estimate.RegenerateInvoiceEstimateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/regenerate_invoice_estimate", url.PathEscape(id)), params)
 }
-func UpcomingInvoicesEstimate(id string) chargebee.RequestObj {
+func UpcomingInvoicesEstimate(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/customers/%v/upcoming_invoices_estimate", url.PathEscape(id)), nil)
 }
-func ChangeTermEnd(id string, params *estimate.ChangeTermEndRequestParams) chargebee.RequestObj {
+func ChangeTermEnd(id string, params *estimate.ChangeTermEndRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/change_term_end_estimate", url.PathEscape(id)), params)
 }
-func CancelSubscription(id string, params *estimate.CancelSubscriptionRequestParams) chargebee.RequestObj {
+func CancelSubscription(id string, params *estimate.CancelSubscriptionRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/cancel_subscription_estimate", url.PathEscape(id)), params)
 }
-func CancelSubscriptionForItems(id string, params *estimate.CancelSubscriptionForItemsRequestParams) chargebee.RequestObj {
+func CancelSubscriptionForItems(id string, params *estimate.CancelSubscriptionForItemsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/cancel_subscription_for_items_estimate", url.PathEscape(id)), params)
 }
-func PauseSubscription(id string, params *estimate.PauseSubscriptionRequestParams) chargebee.RequestObj {
+func PauseSubscription(id string, params *estimate.PauseSubscriptionRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/pause_subscription_estimate", url.PathEscape(id)), params)
 }
-func ResumeSubscription(id string, params *estimate.ResumeSubscriptionRequestParams) chargebee.RequestObj {
+func ResumeSubscription(id string, params *estimate.ResumeSubscriptionRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/resume_subscription_estimate", url.PathEscape(id)), params)
 }
-func GiftSubscription(params *estimate.GiftSubscriptionRequestParams) chargebee.RequestObj {
+func GiftSubscription(params *estimate.GiftSubscriptionRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/estimates/gift_subscription"), params)
 }
-func GiftSubscriptionForItems(params *estimate.GiftSubscriptionForItemsRequestParams) chargebee.RequestObj {
+func GiftSubscriptionForItems(params *estimate.GiftSubscriptionForItemsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/estimates/gift_subscription_for_items"), params)
 }
-func CreateInvoice(params *estimate.CreateInvoiceRequestParams) chargebee.RequestObj {
+func CreateInvoice(params *estimate.CreateInvoiceRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/estimates/create_invoice"), params)
 }
-func CreateInvoiceForItems(params *estimate.CreateInvoiceForItemsRequestParams) chargebee.RequestObj {
+func CreateInvoiceForItems(params *estimate.CreateInvoiceForItemsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/estimates/create_invoice_for_items"), params)
 }
-func PaymentSchedules(params *estimate.PaymentSchedulesRequestParams) chargebee.RequestObj {
+func PaymentSchedules(params *estimate.PaymentSchedulesRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/estimates/payment_schedules"), params).SetIdempotency(true)
 }

--- a/actions/event/event.go
+++ b/actions/event/event.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 )
 
-func List(params *event.ListRequestParams) chargebee.RequestObj {
+func List(params *event.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/events"), params)
 }
 func Retrieve(id string) chargebee.RequestObj {

--- a/actions/event/event.go
+++ b/actions/event/event.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 )
 
-func List(params *event.ListRequestParams) chargebee.ListRequestObj {
+func List(params *event.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/events"), params)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/events/%v", url.PathEscape(id)), nil)
 }
 func Content(event event.Event) *chargebee.Result {

--- a/actions/export/export.go
+++ b/actions/export/export.go
@@ -10,58 +10,58 @@ import (
 	"time"
 )
 
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/exports/%v", url.PathEscape(id)), nil)
 }
-func RevenueRecognition(params *export.RevenueRecognitionRequestParams) chargebee.RequestObj {
+func RevenueRecognition(params *export.RevenueRecognitionRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/exports/revenue_recognition"), params).SetIdempotency(true)
 }
-func DeferredRevenue(params *export.DeferredRevenueRequestParams) chargebee.RequestObj {
+func DeferredRevenue(params *export.DeferredRevenueRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/exports/deferred_revenue"), params).SetIdempotency(true)
 }
-func Plans(params *export.PlansRequestParams) chargebee.RequestObj {
+func Plans(params *export.PlansRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/exports/plans"), params).SetIdempotency(true)
 }
-func Addons(params *export.AddonsRequestParams) chargebee.RequestObj {
+func Addons(params *export.AddonsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/exports/addons"), params).SetIdempotency(true)
 }
-func Coupons(params *export.CouponsRequestParams) chargebee.RequestObj {
+func Coupons(params *export.CouponsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/exports/coupons"), params).SetIdempotency(true)
 }
-func Customers(params *export.CustomersRequestParams) chargebee.RequestObj {
+func Customers(params *export.CustomersRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/exports/customers"), params).SetIdempotency(true)
 }
-func Subscriptions(params *export.SubscriptionsRequestParams) chargebee.RequestObj {
+func Subscriptions(params *export.SubscriptionsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/exports/subscriptions"), params).SetIdempotency(true)
 }
-func Invoices(params *export.InvoicesRequestParams) chargebee.RequestObj {
+func Invoices(params *export.InvoicesRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/exports/invoices"), params).SetIdempotency(true)
 }
-func CreditNotes(params *export.CreditNotesRequestParams) chargebee.RequestObj {
+func CreditNotes(params *export.CreditNotesRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/exports/credit_notes"), params).SetIdempotency(true)
 }
-func Transactions(params *export.TransactionsRequestParams) chargebee.RequestObj {
+func Transactions(params *export.TransactionsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/exports/transactions"), params).SetIdempotency(true)
 }
-func Orders(params *export.OrdersRequestParams) chargebee.RequestObj {
+func Orders(params *export.OrdersRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/exports/orders"), params).SetIdempotency(true)
 }
-func ItemFamilies(params *export.ItemFamiliesRequestParams) chargebee.RequestObj {
+func ItemFamilies(params *export.ItemFamiliesRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/exports/item_families"), params).SetIdempotency(true)
 }
-func Items(params *export.ItemsRequestParams) chargebee.RequestObj {
+func Items(params *export.ItemsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/exports/items"), params).SetIdempotency(true)
 }
-func ItemPrices(params *export.ItemPricesRequestParams) chargebee.RequestObj {
+func ItemPrices(params *export.ItemPricesRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/exports/item_prices"), params).SetIdempotency(true)
 }
-func AttachedItems(params *export.AttachedItemsRequestParams) chargebee.RequestObj {
+func AttachedItems(params *export.AttachedItemsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/exports/attached_items"), params).SetIdempotency(true)
 }
-func DifferentialPrices(params *export.DifferentialPricesRequestParams) chargebee.RequestObj {
+func DifferentialPrices(params *export.DifferentialPricesRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/exports/differential_prices"), params).SetIdempotency(true)
 }
-func PriceVariants(params *export.PriceVariantsRequestParams) chargebee.RequestObj {
+func PriceVariants(params *export.PriceVariantsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/exports/price_variants"), params).SetIdempotency(true)
 }
 func WaitForExportCompletion(exp export.Export) (export.Export, error) {

--- a/actions/feature/feature.go
+++ b/actions/feature/feature.go
@@ -7,27 +7,27 @@ import (
 	"net/url"
 )
 
-func List(params *feature.ListRequestParams) chargebee.ListRequestObj {
+func List(params *feature.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/features"), params)
 }
-func Create(params *feature.CreateRequestParams) chargebee.RequestObj {
+func Create(params *feature.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/features"), params).SetIdempotency(true)
 }
-func Update(id string, params *feature.UpdateRequestParams) chargebee.RequestObj {
+func Update(id string, params *feature.UpdateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/features/%v", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/features/%v", url.PathEscape(id)), nil)
 }
-func Delete(id string) chargebee.RequestObj {
+func Delete(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/features/%v/delete", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func Activate(id string) chargebee.RequestObj {
+func Activate(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/features/%v/activate_command", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func Archive(id string) chargebee.RequestObj {
+func Archive(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/features/%v/archive_command", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func Reactivate(id string) chargebee.RequestObj {
+func Reactivate(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/features/%v/reactivate_command", url.PathEscape(id)), nil).SetIdempotency(true)
 }

--- a/actions/feature/feature.go
+++ b/actions/feature/feature.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 )
 
-func List(params *feature.ListRequestParams) chargebee.RequestObj {
+func List(params *feature.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/features"), params)
 }
 func Create(params *feature.CreateRequestParams) chargebee.RequestObj {

--- a/actions/gift/gift.go
+++ b/actions/gift/gift.go
@@ -16,7 +16,7 @@ func CreateForItems(params *gift.CreateForItemsRequestParams) chargebee.RequestO
 func Retrieve(id string) chargebee.RequestObj {
 	return chargebee.Send("GET", fmt.Sprintf("/gifts/%v", url.PathEscape(id)), nil)
 }
-func List(params *gift.ListRequestParams) chargebee.RequestObj {
+func List(params *gift.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/gifts"), params)
 }
 func Claim(id string) chargebee.RequestObj {

--- a/actions/gift/gift.go
+++ b/actions/gift/gift.go
@@ -7,24 +7,24 @@ import (
 	"net/url"
 )
 
-func Create(params *gift.CreateRequestParams) chargebee.RequestObj {
+func Create(params *gift.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/gifts"), params).SetIdempotency(true)
 }
-func CreateForItems(params *gift.CreateForItemsRequestParams) chargebee.RequestObj {
+func CreateForItems(params *gift.CreateForItemsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/gifts/create_for_items"), params).SetIdempotency(true)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/gifts/%v", url.PathEscape(id)), nil)
 }
-func List(params *gift.ListRequestParams) chargebee.ListRequestObj {
+func List(params *gift.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/gifts"), params)
 }
-func Claim(id string) chargebee.RequestObj {
+func Claim(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/gifts/%v/claim", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func Cancel(id string) chargebee.RequestObj {
+func Cancel(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/gifts/%v/cancel", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func UpdateGift(id string, params *gift.UpdateGiftRequestParams) chargebee.RequestObj {
+func UpdateGift(id string, params *gift.UpdateGiftRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/gifts/%v/update_gift", url.PathEscape(id)), params).SetIdempotency(true)
 }

--- a/actions/hostedpage/hosted_page.go
+++ b/actions/hostedpage/hosted_page.go
@@ -8,70 +8,70 @@ import (
 	"net/url"
 )
 
-func CheckoutNew(params *hostedpage.CheckoutNewRequestParams) chargebee.RequestObj {
+func CheckoutNew(params *hostedpage.CheckoutNewRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/hosted_pages/checkout_new"), params).SetIdempotency(true)
 }
-func CheckoutOneTime(params *hostedpage.CheckoutOneTimeRequestParams) chargebee.RequestObj {
+func CheckoutOneTime(params *hostedpage.CheckoutOneTimeRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/hosted_pages/checkout_one_time"), params).SetIdempotency(true)
 }
-func CheckoutOneTimeForItems(params *hostedpage.CheckoutOneTimeForItemsRequestParams) chargebee.RequestObj {
+func CheckoutOneTimeForItems(params *hostedpage.CheckoutOneTimeForItemsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/hosted_pages/checkout_one_time_for_items"), params).SetIdempotency(true)
 }
-func CheckoutNewForItems(params *hostedpage.CheckoutNewForItemsRequestParams) chargebee.RequestObj {
+func CheckoutNewForItems(params *hostedpage.CheckoutNewForItemsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/hosted_pages/checkout_new_for_items"), params).SetIdempotency(true)
 }
-func CheckoutExisting(params *hostedpage.CheckoutExistingRequestParams) chargebee.RequestObj {
+func CheckoutExisting(params *hostedpage.CheckoutExistingRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/hosted_pages/checkout_existing"), params).SetIdempotency(true)
 }
-func CheckoutExistingForItems(params *hostedpage.CheckoutExistingForItemsRequestParams) chargebee.RequestObj {
+func CheckoutExistingForItems(params *hostedpage.CheckoutExistingForItemsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/hosted_pages/checkout_existing_for_items"), params).SetIdempotency(true)
 }
-func UpdateCard(params *hostedpage.UpdateCardRequestParams) chargebee.RequestObj {
+func UpdateCard(params *hostedpage.UpdateCardRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/hosted_pages/update_card"), params).SetIdempotency(true)
 }
-func UpdatePaymentMethod(params *hostedpage.UpdatePaymentMethodRequestParams) chargebee.RequestObj {
+func UpdatePaymentMethod(params *hostedpage.UpdatePaymentMethodRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/hosted_pages/update_payment_method"), params).SetIdempotency(true)
 }
-func ManagePaymentSources(params *hostedpage.ManagePaymentSourcesRequestParams) chargebee.RequestObj {
+func ManagePaymentSources(params *hostedpage.ManagePaymentSourcesRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/hosted_pages/manage_payment_sources"), params).SetIdempotency(true)
 }
-func CollectNow(params *hostedpage.CollectNowRequestParams) chargebee.RequestObj {
+func CollectNow(params *hostedpage.CollectNowRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/hosted_pages/collect_now"), params).SetIdempotency(true)
 }
-func AcceptQuote(params *hostedpage.AcceptQuoteRequestParams) chargebee.RequestObj {
+func AcceptQuote(params *hostedpage.AcceptQuoteRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/hosted_pages/accept_quote"), params).SetIdempotency(true)
 }
-func ExtendSubscription(params *hostedpage.ExtendSubscriptionRequestParams) chargebee.RequestObj {
+func ExtendSubscription(params *hostedpage.ExtendSubscriptionRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/hosted_pages/extend_subscription"), params).SetIdempotency(true)
 }
-func CheckoutGift(params *hostedpage.CheckoutGiftRequestParams) chargebee.RequestObj {
+func CheckoutGift(params *hostedpage.CheckoutGiftRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/hosted_pages/checkout_gift"), params).SetIdempotency(true)
 }
-func CheckoutGiftForItems(params *hostedpage.CheckoutGiftForItemsRequestParams) chargebee.RequestObj {
+func CheckoutGiftForItems(params *hostedpage.CheckoutGiftForItemsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/hosted_pages/checkout_gift_for_items"), params).SetIdempotency(true)
 }
-func ClaimGift(params *hostedpage.ClaimGiftRequestParams) chargebee.RequestObj {
+func ClaimGift(params *hostedpage.ClaimGiftRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/hosted_pages/claim_gift"), params).SetIdempotency(true)
 }
-func RetrieveAgreementPdf(params *hostedpage.RetrieveAgreementPdfRequestParams) chargebee.RequestObj {
+func RetrieveAgreementPdf(params *hostedpage.RetrieveAgreementPdfRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/hosted_pages/retrieve_agreement_pdf"), params).SetIdempotency(true)
 }
-func Acknowledge(id string) chargebee.RequestObj {
+func Acknowledge(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/hosted_pages/%v/acknowledge", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/hosted_pages/%v", url.PathEscape(id)), nil)
 }
-func List(params *hostedpage.ListRequestParams) chargebee.ListRequestObj {
+func List(params *hostedpage.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/hosted_pages"), params)
 }
-func PreCancel(params *hostedpage.PreCancelRequestParams) chargebee.RequestObj {
+func PreCancel(params *hostedpage.PreCancelRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/hosted_pages/pre_cancel"), params).SetIdempotency(true)
 }
-func Events(params *hostedpage.EventsRequestParams) chargebee.RequestObj {
+func Events(params *hostedpage.EventsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/hosted_pages/events"), params).SetIdempotency(true)
 }
-func ViewVoucher(params *hostedpage.ViewVoucherRequestParams) chargebee.RequestObj {
+func ViewVoucher(params *hostedpage.ViewVoucherRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/hosted_pages/view_voucher"), params).SetIdempotency(true)
 }
 func Content(page hostedpage.HostedPage) *chargebee.Result {

--- a/actions/hostedpage/hosted_page.go
+++ b/actions/hostedpage/hosted_page.go
@@ -62,7 +62,7 @@ func Acknowledge(id string) chargebee.RequestObj {
 func Retrieve(id string) chargebee.RequestObj {
 	return chargebee.Send("GET", fmt.Sprintf("/hosted_pages/%v", url.PathEscape(id)), nil)
 }
-func List(params *hostedpage.ListRequestParams) chargebee.RequestObj {
+func List(params *hostedpage.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/hosted_pages"), params)
 }
 func PreCancel(params *hostedpage.PreCancelRequestParams) chargebee.RequestObj {

--- a/actions/inappsubscription/in_app_subscription.go
+++ b/actions/inappsubscription/in_app_subscription.go
@@ -7,15 +7,15 @@ import (
 	"net/url"
 )
 
-func ProcessReceipt(id string, params *inappsubscription.ProcessReceiptRequestParams) chargebee.RequestObj {
+func ProcessReceipt(id string, params *inappsubscription.ProcessReceiptRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/in_app_subscriptions/%v/process_purchase_command", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func ImportReceipt(id string, params *inappsubscription.ImportReceiptRequestParams) chargebee.RequestObj {
+func ImportReceipt(id string, params *inappsubscription.ImportReceiptRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/in_app_subscriptions/%v/import_receipt", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func ImportSubscription(id string, params *inappsubscription.ImportSubscriptionRequestParams) chargebee.RequestObj {
+func ImportSubscription(id string, params *inappsubscription.ImportSubscriptionRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/in_app_subscriptions/%v/import_subscription", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func RetrieveStoreSubs(id string, params *inappsubscription.RetrieveStoreSubsRequestParams) chargebee.RequestObj {
+func RetrieveStoreSubs(id string, params *inappsubscription.RetrieveStoreSubsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/in_app_subscriptions/%v/retrieve", url.PathEscape(id)), params).SetIdempotency(true)
 }

--- a/actions/invoice/invoice.go
+++ b/actions/invoice/invoice.go
@@ -7,123 +7,123 @@ import (
 	"net/url"
 )
 
-func Create(params *invoice.CreateRequestParams) chargebee.RequestObj {
+func Create(params *invoice.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices"), params).SetIdempotency(true)
 }
-func CreateForChargeItemsAndCharges(params *invoice.CreateForChargeItemsAndChargesRequestParams) chargebee.RequestObj {
+func CreateForChargeItemsAndCharges(params *invoice.CreateForChargeItemsAndChargesRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/create_for_charge_items_and_charges"), params).SetIdempotency(true)
 }
-func Charge(params *invoice.ChargeRequestParams) chargebee.RequestObj {
+func Charge(params *invoice.ChargeRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/charge"), params).SetIdempotency(true)
 }
-func ChargeAddon(params *invoice.ChargeAddonRequestParams) chargebee.RequestObj {
+func ChargeAddon(params *invoice.ChargeAddonRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/charge_addon"), params).SetIdempotency(true)
 }
-func CreateForChargeItem(params *invoice.CreateForChargeItemRequestParams) chargebee.RequestObj {
+func CreateForChargeItem(params *invoice.CreateForChargeItemRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/create_for_charge_item"), params).SetIdempotency(true)
 }
-func StopDunning(id string, params *invoice.StopDunningRequestParams) chargebee.RequestObj {
+func StopDunning(id string, params *invoice.StopDunningRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/stop_dunning", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func PauseDunning(id string, params *invoice.PauseDunningRequestParams) chargebee.RequestObj {
+func PauseDunning(id string, params *invoice.PauseDunningRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/pause_dunning", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func ResumeDunning(id string, params *invoice.ResumeDunningRequestParams) chargebee.RequestObj {
+func ResumeDunning(id string, params *invoice.ResumeDunningRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/resume_dunning", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func ImportInvoice(params *invoice.ImportInvoiceRequestParams) chargebee.RequestObj {
+func ImportInvoice(params *invoice.ImportInvoiceRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/import_invoice"), params).SetIdempotency(true)
 }
-func ApplyPayments(id string, params *invoice.ApplyPaymentsRequestParams) chargebee.RequestObj {
+func ApplyPayments(id string, params *invoice.ApplyPaymentsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/apply_payments", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func SyncUsages(id string) chargebee.RequestObj {
+func SyncUsages(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/sync_usages", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func DeleteLineItems(id string, params *invoice.DeleteLineItemsRequestParams) chargebee.RequestObj {
+func DeleteLineItems(id string, params *invoice.DeleteLineItemsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/delete_line_items", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func ApplyCredits(id string, params *invoice.ApplyCreditsRequestParams) chargebee.RequestObj {
+func ApplyCredits(id string, params *invoice.ApplyCreditsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/apply_credits", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func List(params *invoice.ListRequestParams) chargebee.ListRequestObj {
+func List(params *invoice.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/invoices"), params)
 }
-func InvoicesForCustomer(id string, params *invoice.InvoicesForCustomerRequestParams) chargebee.ListRequestObj {
+func InvoicesForCustomer(id string, params *invoice.InvoicesForCustomerRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/invoices", url.PathEscape(id)), params)
 }
-func InvoicesForSubscription(id string, params *invoice.InvoicesForSubscriptionRequestParams) chargebee.ListRequestObj {
+func InvoicesForSubscription(id string, params *invoice.InvoicesForSubscriptionRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/subscriptions/%v/invoices", url.PathEscape(id)), params)
 }
-func Retrieve(id string, params *invoice.RetrieveRequestParams) chargebee.RequestObj {
+func Retrieve(id string, params *invoice.RetrieveRequestParams) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/invoices/%v", url.PathEscape(id)), params)
 }
-func Pdf(id string, params *invoice.PdfRequestParams) chargebee.RequestObj {
+func Pdf(id string, params *invoice.PdfRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/pdf", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func DownloadEinvoice(id string) chargebee.RequestObj {
+func DownloadEinvoice(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/invoices/%v/download_einvoice", url.PathEscape(id)), nil)
 }
-func ListPaymentReferenceNumbers(params *invoice.ListPaymentReferenceNumbersRequestParams) chargebee.ListRequestObj {
+func ListPaymentReferenceNumbers(params *invoice.ListPaymentReferenceNumbersRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/invoices/payment_reference_numbers"), params)
 }
-func AddCharge(id string, params *invoice.AddChargeRequestParams) chargebee.RequestObj {
+func AddCharge(id string, params *invoice.AddChargeRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/add_charge", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func AddAddonCharge(id string, params *invoice.AddAddonChargeRequestParams) chargebee.RequestObj {
+func AddAddonCharge(id string, params *invoice.AddAddonChargeRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/add_addon_charge", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func AddChargeItem(id string, params *invoice.AddChargeItemRequestParams) chargebee.RequestObj {
+func AddChargeItem(id string, params *invoice.AddChargeItemRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/add_charge_item", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Close(id string, params *invoice.CloseRequestParams) chargebee.RequestObj {
+func Close(id string, params *invoice.CloseRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/close", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func CollectPayment(id string, params *invoice.CollectPaymentRequestParams) chargebee.RequestObj {
+func CollectPayment(id string, params *invoice.CollectPaymentRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/collect_payment", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func RecordPayment(id string, params *invoice.RecordPaymentRequestParams) chargebee.RequestObj {
+func RecordPayment(id string, params *invoice.RecordPaymentRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/record_payment", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func RecordTaxWithheld(id string, params *invoice.RecordTaxWithheldRequestParams) chargebee.RequestObj {
+func RecordTaxWithheld(id string, params *invoice.RecordTaxWithheldRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/record_tax_withheld", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func RemoveTaxWithheld(id string, params *invoice.RemoveTaxWithheldRequestParams) chargebee.RequestObj {
+func RemoveTaxWithheld(id string, params *invoice.RemoveTaxWithheldRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/remove_tax_withheld", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Refund(id string, params *invoice.RefundRequestParams) chargebee.RequestObj {
+func Refund(id string, params *invoice.RefundRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/refund", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func RecordRefund(id string, params *invoice.RecordRefundRequestParams) chargebee.RequestObj {
+func RecordRefund(id string, params *invoice.RecordRefundRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/record_refund", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func RemovePayment(id string, params *invoice.RemovePaymentRequestParams) chargebee.RequestObj {
+func RemovePayment(id string, params *invoice.RemovePaymentRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/remove_payment", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func RemoveCreditNote(id string, params *invoice.RemoveCreditNoteRequestParams) chargebee.RequestObj {
+func RemoveCreditNote(id string, params *invoice.RemoveCreditNoteRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/remove_credit_note", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func VoidInvoice(id string, params *invoice.VoidInvoiceRequestParams) chargebee.RequestObj {
+func VoidInvoice(id string, params *invoice.VoidInvoiceRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/void", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func WriteOff(id string, params *invoice.WriteOffRequestParams) chargebee.RequestObj {
+func WriteOff(id string, params *invoice.WriteOffRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/write_off", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Delete(id string, params *invoice.DeleteRequestParams) chargebee.RequestObj {
+func Delete(id string, params *invoice.DeleteRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/delete", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func UpdateDetails(id string, params *invoice.UpdateDetailsRequestParams) chargebee.RequestObj {
+func UpdateDetails(id string, params *invoice.UpdateDetailsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/update_details", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func ApplyPaymentScheduleScheme(id string, params *invoice.ApplyPaymentScheduleSchemeRequestParams) chargebee.RequestObj {
+func ApplyPaymentScheduleScheme(id string, params *invoice.ApplyPaymentScheduleSchemeRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/apply_payment_schedule_scheme", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func PaymentSchedules(id string) chargebee.RequestObj {
+func PaymentSchedules(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/invoices/%v/payment_schedules", url.PathEscape(id)), nil)
 }
-func ResendEinvoice(id string) chargebee.RequestObj {
+func ResendEinvoice(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/resend_einvoice", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func SendEinvoice(id string) chargebee.RequestObj {
+func SendEinvoice(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/send_einvoice", url.PathEscape(id)), nil).SetIdempotency(true)
 }

--- a/actions/invoice/invoice.go
+++ b/actions/invoice/invoice.go
@@ -46,13 +46,13 @@ func DeleteLineItems(id string, params *invoice.DeleteLineItemsRequestParams) ch
 func ApplyCredits(id string, params *invoice.ApplyCreditsRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/invoices/%v/apply_credits", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func List(params *invoice.ListRequestParams) chargebee.RequestObj {
+func List(params *invoice.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/invoices"), params)
 }
-func InvoicesForCustomer(id string, params *invoice.InvoicesForCustomerRequestParams) chargebee.RequestObj {
+func InvoicesForCustomer(id string, params *invoice.InvoicesForCustomerRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/invoices", url.PathEscape(id)), params)
 }
-func InvoicesForSubscription(id string, params *invoice.InvoicesForSubscriptionRequestParams) chargebee.RequestObj {
+func InvoicesForSubscription(id string, params *invoice.InvoicesForSubscriptionRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/subscriptions/%v/invoices", url.PathEscape(id)), params)
 }
 func Retrieve(id string, params *invoice.RetrieveRequestParams) chargebee.RequestObj {
@@ -64,7 +64,7 @@ func Pdf(id string, params *invoice.PdfRequestParams) chargebee.RequestObj {
 func DownloadEinvoice(id string) chargebee.RequestObj {
 	return chargebee.Send("GET", fmt.Sprintf("/invoices/%v/download_einvoice", url.PathEscape(id)), nil)
 }
-func ListPaymentReferenceNumbers(params *invoice.ListPaymentReferenceNumbersRequestParams) chargebee.RequestObj {
+func ListPaymentReferenceNumbers(params *invoice.ListPaymentReferenceNumbersRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/invoices/payment_reference_numbers"), params)
 }
 func AddCharge(id string, params *invoice.AddChargeRequestParams) chargebee.RequestObj {

--- a/actions/item/item.go
+++ b/actions/item/item.go
@@ -7,18 +7,18 @@ import (
 	"net/url"
 )
 
-func Create(params *item.CreateRequestParams) chargebee.RequestObj {
+func Create(params *item.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/items"), params).SetIdempotency(true)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/items/%v", url.PathEscape(id)), nil)
 }
-func Update(id string, params *item.UpdateRequestParams) chargebee.RequestObj {
+func Update(id string, params *item.UpdateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/items/%v", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func List(params *item.ListRequestParams) chargebee.ListRequestObj {
+func List(params *item.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/items"), params)
 }
-func Delete(id string) chargebee.RequestObj {
+func Delete(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/items/%v/delete", url.PathEscape(id)), nil).SetIdempotency(true)
 }

--- a/actions/item/item.go
+++ b/actions/item/item.go
@@ -16,7 +16,7 @@ func Retrieve(id string) chargebee.RequestObj {
 func Update(id string, params *item.UpdateRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/items/%v", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func List(params *item.ListRequestParams) chargebee.RequestObj {
+func List(params *item.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/items"), params)
 }
 func Delete(id string) chargebee.RequestObj {

--- a/actions/itementitlement/item_entitlement.go
+++ b/actions/itementitlement/item_entitlement.go
@@ -7,15 +7,15 @@ import (
 	"net/url"
 )
 
-func ItemEntitlementsForItem(id string, params *itementitlement.ItemEntitlementsForItemRequestParams) chargebee.ListRequestObj {
+func ItemEntitlementsForItem(id string, params *itementitlement.ItemEntitlementsForItemRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/items/%v/item_entitlements", url.PathEscape(id)), params)
 }
-func ItemEntitlementsForFeature(id string, params *itementitlement.ItemEntitlementsForFeatureRequestParams) chargebee.ListRequestObj {
+func ItemEntitlementsForFeature(id string, params *itementitlement.ItemEntitlementsForFeatureRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/features/%v/item_entitlements", url.PathEscape(id)), params)
 }
-func AddItemEntitlements(id string, params *itementitlement.AddItemEntitlementsRequestParams) chargebee.RequestObj {
+func AddItemEntitlements(id string, params *itementitlement.AddItemEntitlementsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/features/%v/item_entitlements", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func UpsertOrRemoveItemEntitlementsForItem(id string, params *itementitlement.UpsertOrRemoveItemEntitlementsForItemRequestParams) chargebee.RequestObj {
+func UpsertOrRemoveItemEntitlementsForItem(id string, params *itementitlement.UpsertOrRemoveItemEntitlementsForItemRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/items/%v/item_entitlements", url.PathEscape(id)), params).SetIdempotency(true)
 }

--- a/actions/itementitlement/item_entitlement.go
+++ b/actions/itementitlement/item_entitlement.go
@@ -7,10 +7,10 @@ import (
 	"net/url"
 )
 
-func ItemEntitlementsForItem(id string, params *itementitlement.ItemEntitlementsForItemRequestParams) chargebee.RequestObj {
+func ItemEntitlementsForItem(id string, params *itementitlement.ItemEntitlementsForItemRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/items/%v/item_entitlements", url.PathEscape(id)), params)
 }
-func ItemEntitlementsForFeature(id string, params *itementitlement.ItemEntitlementsForFeatureRequestParams) chargebee.RequestObj {
+func ItemEntitlementsForFeature(id string, params *itementitlement.ItemEntitlementsForFeatureRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/features/%v/item_entitlements", url.PathEscape(id)), params)
 }
 func AddItemEntitlements(id string, params *itementitlement.AddItemEntitlementsRequestParams) chargebee.RequestObj {

--- a/actions/itemfamily/item_family.go
+++ b/actions/itemfamily/item_family.go
@@ -13,7 +13,7 @@ func Create(params *itemfamily.CreateRequestParams) chargebee.RequestObj {
 func Retrieve(id string) chargebee.RequestObj {
 	return chargebee.Send("GET", fmt.Sprintf("/item_families/%v", url.PathEscape(id)), nil)
 }
-func List(params *itemfamily.ListRequestParams) chargebee.RequestObj {
+func List(params *itemfamily.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/item_families"), params)
 }
 func Update(id string, params *itemfamily.UpdateRequestParams) chargebee.RequestObj {

--- a/actions/itemfamily/item_family.go
+++ b/actions/itemfamily/item_family.go
@@ -7,18 +7,18 @@ import (
 	"net/url"
 )
 
-func Create(params *itemfamily.CreateRequestParams) chargebee.RequestObj {
+func Create(params *itemfamily.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/item_families"), params).SetIdempotency(true)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/item_families/%v", url.PathEscape(id)), nil)
 }
-func List(params *itemfamily.ListRequestParams) chargebee.ListRequestObj {
+func List(params *itemfamily.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/item_families"), params)
 }
-func Update(id string, params *itemfamily.UpdateRequestParams) chargebee.RequestObj {
+func Update(id string, params *itemfamily.UpdateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/item_families/%v", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Delete(id string) chargebee.RequestObj {
+func Delete(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/item_families/%v/delete", url.PathEscape(id)), nil).SetIdempotency(true)
 }

--- a/actions/itemprice/item_price.go
+++ b/actions/itemprice/item_price.go
@@ -7,24 +7,24 @@ import (
 	"net/url"
 )
 
-func Create(params *itemprice.CreateRequestParams) chargebee.RequestObj {
+func Create(params *itemprice.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/item_prices"), params).SetIdempotency(true)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/item_prices/%v", url.PathEscape(id)), nil)
 }
-func Update(id string, params *itemprice.UpdateRequestParams) chargebee.RequestObj {
+func Update(id string, params *itemprice.UpdateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/item_prices/%v", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func List(params *itemprice.ListRequestParams) chargebee.ListRequestObj {
+func List(params *itemprice.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/item_prices"), params)
 }
-func Delete(id string) chargebee.RequestObj {
+func Delete(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/item_prices/%v/delete", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func FindApplicableItems(id string, params *itemprice.FindApplicableItemsRequestParams) chargebee.ListRequestObj {
+func FindApplicableItems(id string, params *itemprice.FindApplicableItemsRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/item_prices/%v/applicable_items", url.PathEscape(id)), params)
 }
-func FindApplicableItemPrices(id string, params *itemprice.FindApplicableItemPricesRequestParams) chargebee.ListRequestObj {
+func FindApplicableItemPrices(id string, params *itemprice.FindApplicableItemPricesRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/item_prices/%v/applicable_item_prices", url.PathEscape(id)), params)
 }

--- a/actions/itemprice/item_price.go
+++ b/actions/itemprice/item_price.go
@@ -16,15 +16,15 @@ func Retrieve(id string) chargebee.RequestObj {
 func Update(id string, params *itemprice.UpdateRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/item_prices/%v", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func List(params *itemprice.ListRequestParams) chargebee.RequestObj {
+func List(params *itemprice.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/item_prices"), params)
 }
 func Delete(id string) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/item_prices/%v/delete", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func FindApplicableItems(id string, params *itemprice.FindApplicableItemsRequestParams) chargebee.RequestObj {
+func FindApplicableItems(id string, params *itemprice.FindApplicableItemsRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/item_prices/%v/applicable_items", url.PathEscape(id)), params)
 }
-func FindApplicableItemPrices(id string, params *itemprice.FindApplicableItemPricesRequestParams) chargebee.RequestObj {
+func FindApplicableItemPrices(id string, params *itemprice.FindApplicableItemPricesRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/item_prices/%v/applicable_item_prices", url.PathEscape(id)), params)
 }

--- a/actions/omnichannelonetimeorder/omnichannel_one_time_order.go
+++ b/actions/omnichannelonetimeorder/omnichannel_one_time_order.go
@@ -10,6 +10,6 @@ import (
 func Retrieve(id string) chargebee.RequestObj {
 	return chargebee.Send("GET", fmt.Sprintf("/omnichannel_one_time_orders/%v", url.PathEscape(id)), nil)
 }
-func List(params *omnichannelonetimeorder.ListRequestParams) chargebee.RequestObj {
+func List(params *omnichannelonetimeorder.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/omnichannel_one_time_orders"), params)
 }

--- a/actions/omnichannelonetimeorder/omnichannel_one_time_order.go
+++ b/actions/omnichannelonetimeorder/omnichannel_one_time_order.go
@@ -7,9 +7,9 @@ import (
 	"net/url"
 )
 
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/omnichannel_one_time_orders/%v", url.PathEscape(id)), nil)
 }
-func List(params *omnichannelonetimeorder.ListRequestParams) chargebee.ListRequestObj {
+func List(params *omnichannelonetimeorder.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/omnichannel_one_time_orders"), params)
 }

--- a/actions/omnichannelsubscription/omnichannel_subscription.go
+++ b/actions/omnichannelsubscription/omnichannel_subscription.go
@@ -10,9 +10,9 @@ import (
 func Retrieve(id string) chargebee.RequestObj {
 	return chargebee.Send("GET", fmt.Sprintf("/omnichannel_subscriptions/%v", url.PathEscape(id)), nil)
 }
-func List(params *omnichannelsubscription.ListRequestParams) chargebee.RequestObj {
+func List(params *omnichannelsubscription.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/omnichannel_subscriptions"), params)
 }
-func OmnichannelTransactionsForOmnichannelSubscription(id string, params *omnichannelsubscription.OmnichannelTransactionsForOmnichannelSubscriptionRequestParams) chargebee.RequestObj {
+func OmnichannelTransactionsForOmnichannelSubscription(id string, params *omnichannelsubscription.OmnichannelTransactionsForOmnichannelSubscriptionRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/omnichannel_subscriptions/%v/omnichannel_transactions", url.PathEscape(id)), params)
 }

--- a/actions/omnichannelsubscription/omnichannel_subscription.go
+++ b/actions/omnichannelsubscription/omnichannel_subscription.go
@@ -7,12 +7,12 @@ import (
 	"net/url"
 )
 
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/omnichannel_subscriptions/%v", url.PathEscape(id)), nil)
 }
-func List(params *omnichannelsubscription.ListRequestParams) chargebee.ListRequestObj {
+func List(params *omnichannelsubscription.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/omnichannel_subscriptions"), params)
 }
-func OmnichannelTransactionsForOmnichannelSubscription(id string, params *omnichannelsubscription.OmnichannelTransactionsForOmnichannelSubscriptionRequestParams) chargebee.ListRequestObj {
+func OmnichannelTransactionsForOmnichannelSubscription(id string, params *omnichannelsubscription.OmnichannelTransactionsForOmnichannelSubscriptionRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/omnichannel_subscriptions/%v/omnichannel_transactions", url.PathEscape(id)), params)
 }

--- a/actions/omnichannelsubscriptionitem/omnichannel_subscription_item.go
+++ b/actions/omnichannelsubscriptionitem/omnichannel_subscription_item.go
@@ -7,6 +7,6 @@ import (
 	"net/url"
 )
 
-func ListOmniSubItemScheduleChanges(id string, params *omnichannelsubscriptionitem.ListOmniSubItemScheduleChangesRequestParams) chargebee.ListRequestObj {
+func ListOmniSubItemScheduleChanges(id string, params *omnichannelsubscriptionitem.ListOmniSubItemScheduleChangesRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/omnichannel_subscription_items/%v/scheduled_changes", url.PathEscape(id)), params)
 }

--- a/actions/omnichannelsubscriptionitem/omnichannel_subscription_item.go
+++ b/actions/omnichannelsubscriptionitem/omnichannel_subscription_item.go
@@ -7,6 +7,6 @@ import (
 	"net/url"
 )
 
-func ListOmniSubItemScheduleChanges(id string, params *omnichannelsubscriptionitem.ListOmniSubItemScheduleChangesRequestParams) chargebee.RequestObj {
+func ListOmniSubItemScheduleChanges(id string, params *omnichannelsubscriptionitem.ListOmniSubItemScheduleChangesRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/omnichannel_subscription_items/%v/scheduled_changes", url.PathEscape(id)), params)
 }

--- a/actions/order/order.go
+++ b/actions/order/order.go
@@ -34,10 +34,10 @@ func Retrieve(id string) chargebee.RequestObj {
 func Delete(id string) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/orders/%v/delete", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func List(params *order.ListRequestParams) chargebee.RequestObj {
+func List(params *order.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/orders"), params)
 }
-func OrdersForInvoice(id string, params *order.OrdersForInvoiceRequestParams) chargebee.RequestObj {
+func OrdersForInvoice(id string, params *order.OrdersForInvoiceRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/invoices/%v/orders", url.PathEscape(id)), params)
 }
 func Resend(id string, params *order.ResendRequestParams) chargebee.RequestObj {

--- a/actions/order/order.go
+++ b/actions/order/order.go
@@ -7,39 +7,39 @@ import (
 	"net/url"
 )
 
-func Create(params *order.CreateRequestParams) chargebee.RequestObj {
+func Create(params *order.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/orders"), params).SetIdempotency(true)
 }
-func Update(id string, params *order.UpdateRequestParams) chargebee.RequestObj {
+func Update(id string, params *order.UpdateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/orders/%v", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func ImportOrder(params *order.ImportOrderRequestParams) chargebee.RequestObj {
+func ImportOrder(params *order.ImportOrderRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/orders/import_order"), params).SetIdempotency(true)
 }
-func AssignOrderNumber(id string) chargebee.RequestObj {
+func AssignOrderNumber(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/orders/%v/assign_order_number", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func Cancel(id string, params *order.CancelRequestParams) chargebee.RequestObj {
+func Cancel(id string, params *order.CancelRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/orders/%v/cancel", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func CreateRefundableCreditNote(id string, params *order.CreateRefundableCreditNoteRequestParams) chargebee.RequestObj {
+func CreateRefundableCreditNote(id string, params *order.CreateRefundableCreditNoteRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/orders/%v/create_refundable_credit_note", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Reopen(id string, params *order.ReopenRequestParams) chargebee.RequestObj {
+func Reopen(id string, params *order.ReopenRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/orders/%v/reopen", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/orders/%v", url.PathEscape(id)), nil)
 }
-func Delete(id string) chargebee.RequestObj {
+func Delete(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/orders/%v/delete", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func List(params *order.ListRequestParams) chargebee.ListRequestObj {
+func List(params *order.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/orders"), params)
 }
-func OrdersForInvoice(id string, params *order.OrdersForInvoiceRequestParams) chargebee.ListRequestObj {
+func OrdersForInvoice(id string, params *order.OrdersForInvoiceRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/invoices/%v/orders", url.PathEscape(id)), params)
 }
-func Resend(id string, params *order.ResendRequestParams) chargebee.RequestObj {
+func Resend(id string, params *order.ResendRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/orders/%v/resend", url.PathEscape(id)), params).SetIdempotency(true)
 }

--- a/actions/paymentintent/payment_intent.go
+++ b/actions/paymentintent/payment_intent.go
@@ -7,12 +7,12 @@ import (
 	"net/url"
 )
 
-func Create(params *paymentintent.CreateRequestParams) chargebee.RequestObj {
+func Create(params *paymentintent.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/payment_intents"), params).SetIdempotency(true)
 }
-func Update(id string, params *paymentintent.UpdateRequestParams) chargebee.RequestObj {
+func Update(id string, params *paymentintent.UpdateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/payment_intents/%v", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/payment_intents/%v", url.PathEscape(id)), nil)
 }

--- a/actions/paymentschedulescheme/payment_schedule_scheme.go
+++ b/actions/paymentschedulescheme/payment_schedule_scheme.go
@@ -7,12 +7,12 @@ import (
 	"net/url"
 )
 
-func Create(params *paymentschedulescheme.CreateRequestParams) chargebee.RequestObj {
+func Create(params *paymentschedulescheme.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/payment_schedule_schemes"), params).SetIdempotency(true)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/payment_schedule_schemes/%v", url.PathEscape(id)), nil)
 }
-func Delete(id string) chargebee.RequestObj {
+func Delete(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/payment_schedule_schemes/%v/delete", url.PathEscape(id)), nil).SetIdempotency(true)
 }

--- a/actions/paymentsource/payment_source.go
+++ b/actions/paymentsource/payment_source.go
@@ -7,51 +7,51 @@ import (
 	"net/url"
 )
 
-func CreateUsingTempToken(params *paymentsource.CreateUsingTempTokenRequestParams) chargebee.RequestObj {
+func CreateUsingTempToken(params *paymentsource.CreateUsingTempTokenRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/create_using_temp_token"), params).SetIdempotency(true)
 }
-func CreateUsingPermanentToken(params *paymentsource.CreateUsingPermanentTokenRequestParams) chargebee.RequestObj {
+func CreateUsingPermanentToken(params *paymentsource.CreateUsingPermanentTokenRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/create_using_permanent_token"), params).SetIdempotency(true)
 }
-func CreateUsingToken(params *paymentsource.CreateUsingTokenRequestParams) chargebee.RequestObj {
+func CreateUsingToken(params *paymentsource.CreateUsingTokenRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/create_using_token"), params).SetIdempotency(true)
 }
-func CreateUsingPaymentIntent(params *paymentsource.CreateUsingPaymentIntentRequestParams) chargebee.RequestObj {
+func CreateUsingPaymentIntent(params *paymentsource.CreateUsingPaymentIntentRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/create_using_payment_intent"), params).SetIdempotency(true)
 }
-func CreateVoucherPaymentSource(params *paymentsource.CreateVoucherPaymentSourceRequestParams) chargebee.RequestObj {
+func CreateVoucherPaymentSource(params *paymentsource.CreateVoucherPaymentSourceRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/create_voucher_payment_source"), params).SetIdempotency(true)
 }
-func CreateCard(params *paymentsource.CreateCardRequestParams) chargebee.RequestObj {
+func CreateCard(params *paymentsource.CreateCardRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/create_card"), params).SetIdempotency(true)
 }
-func CreateBankAccount(params *paymentsource.CreateBankAccountRequestParams) chargebee.RequestObj {
+func CreateBankAccount(params *paymentsource.CreateBankAccountRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/create_bank_account"), params).SetIdempotency(true)
 }
-func UpdateCard(id string, params *paymentsource.UpdateCardRequestParams) chargebee.RequestObj {
+func UpdateCard(id string, params *paymentsource.UpdateCardRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/%v/update_card", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func UpdateBankAccount(id string, params *paymentsource.UpdateBankAccountRequestParams) chargebee.RequestObj {
+func UpdateBankAccount(id string, params *paymentsource.UpdateBankAccountRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/%v/update_bank_account", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func VerifyBankAccount(id string, params *paymentsource.VerifyBankAccountRequestParams) chargebee.RequestObj {
+func VerifyBankAccount(id string, params *paymentsource.VerifyBankAccountRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/%v/verify_bank_account", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/payment_sources/%v", url.PathEscape(id)), nil)
 }
-func List(params *paymentsource.ListRequestParams) chargebee.ListRequestObj {
+func List(params *paymentsource.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/payment_sources"), params)
 }
-func SwitchGatewayAccount(id string, params *paymentsource.SwitchGatewayAccountRequestParams) chargebee.RequestObj {
+func SwitchGatewayAccount(id string, params *paymentsource.SwitchGatewayAccountRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/%v/switch_gateway_account", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func ExportPaymentSource(id string, params *paymentsource.ExportPaymentSourceRequestParams) chargebee.RequestObj {
+func ExportPaymentSource(id string, params *paymentsource.ExportPaymentSourceRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/%v/export_payment_source", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Delete(id string) chargebee.RequestObj {
+func Delete(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/%v/delete", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func DeleteLocal(id string) chargebee.RequestObj {
+func DeleteLocal(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/payment_sources/%v/delete_local", url.PathEscape(id)), nil).SetIdempotency(true)
 }

--- a/actions/paymentsource/payment_source.go
+++ b/actions/paymentsource/payment_source.go
@@ -40,7 +40,7 @@ func VerifyBankAccount(id string, params *paymentsource.VerifyBankAccountRequest
 func Retrieve(id string) chargebee.RequestObj {
 	return chargebee.Send("GET", fmt.Sprintf("/payment_sources/%v", url.PathEscape(id)), nil)
 }
-func List(params *paymentsource.ListRequestParams) chargebee.RequestObj {
+func List(params *paymentsource.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/payment_sources"), params)
 }
 func SwitchGatewayAccount(id string, params *paymentsource.SwitchGatewayAccountRequestParams) chargebee.RequestObj {

--- a/actions/paymentvoucher/payment_voucher.go
+++ b/actions/paymentvoucher/payment_voucher.go
@@ -7,25 +7,25 @@ import (
 	"net/url"
 )
 
-func Create(params *paymentvoucher.CreateRequestParams) chargebee.RequestObj {
+func Create(params *paymentvoucher.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/payment_vouchers"), params).SetIdempotency(true)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/payment_vouchers/%v", url.PathEscape(id)), nil)
 }
-func PaymentVouchersForInvoice(id string, params *paymentvoucher.PaymentVouchersForInvoiceRequestParams) chargebee.ListRequestObj {
+func PaymentVouchersForInvoice(id string, params *paymentvoucher.PaymentVouchersForInvoiceRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/invoices/%v/payment_vouchers", url.PathEscape(id)), params)
 }
-func PaymentVouchersForCustomer(id string, params *paymentvoucher.PaymentVouchersForCustomerRequestParams) chargebee.ListRequestObj {
+func PaymentVouchersForCustomer(id string, params *paymentvoucher.PaymentVouchersForCustomerRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/payment_vouchers", url.PathEscape(id)), params)
 }
 
 // Deprecated: This function is deprecated. Please use PaymentVouchersForInvoice instead.
-func Payment_vouchersForInvoice(id string, params *paymentvoucher.PaymentVouchersForInvoiceRequestParams) chargebee.ListRequestObj {
+func Payment_vouchersForInvoice(id string, params *paymentvoucher.PaymentVouchersForInvoiceRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/invoices/%v/payment_vouchers", url.PathEscape(id)), params)
 }
 
 // Deprecated: This function is deprecated. Please use PaymentVouchersForCustomer instead.
-func Payment_vouchersForCustomer(id string, params *paymentvoucher.PaymentVouchersForCustomerRequestParams) chargebee.ListRequestObj {
+func Payment_vouchersForCustomer(id string, params *paymentvoucher.PaymentVouchersForCustomerRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/payment_vouchers", url.PathEscape(id)), params)
 }

--- a/actions/paymentvoucher/payment_voucher.go
+++ b/actions/paymentvoucher/payment_voucher.go
@@ -13,19 +13,19 @@ func Create(params *paymentvoucher.CreateRequestParams) chargebee.RequestObj {
 func Retrieve(id string) chargebee.RequestObj {
 	return chargebee.Send("GET", fmt.Sprintf("/payment_vouchers/%v", url.PathEscape(id)), nil)
 }
-func PaymentVouchersForInvoice(id string, params *paymentvoucher.PaymentVouchersForInvoiceRequestParams) chargebee.RequestObj {
+func PaymentVouchersForInvoice(id string, params *paymentvoucher.PaymentVouchersForInvoiceRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/invoices/%v/payment_vouchers", url.PathEscape(id)), params)
 }
-func PaymentVouchersForCustomer(id string, params *paymentvoucher.PaymentVouchersForCustomerRequestParams) chargebee.RequestObj {
+func PaymentVouchersForCustomer(id string, params *paymentvoucher.PaymentVouchersForCustomerRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/payment_vouchers", url.PathEscape(id)), params)
 }
 
 // Deprecated: This function is deprecated. Please use PaymentVouchersForInvoice instead.
-func Payment_vouchersForInvoice(id string, params *paymentvoucher.PaymentVouchersForInvoiceRequestParams) chargebee.RequestObj {
+func Payment_vouchersForInvoice(id string, params *paymentvoucher.PaymentVouchersForInvoiceRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/invoices/%v/payment_vouchers", url.PathEscape(id)), params)
 }
 
 // Deprecated: This function is deprecated. Please use PaymentVouchersForCustomer instead.
-func Payment_vouchersForCustomer(id string, params *paymentvoucher.PaymentVouchersForCustomerRequestParams) chargebee.RequestObj {
+func Payment_vouchersForCustomer(id string, params *paymentvoucher.PaymentVouchersForCustomerRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/payment_vouchers", url.PathEscape(id)), params)
 }

--- a/actions/plan/plan.go
+++ b/actions/plan/plan.go
@@ -13,7 +13,7 @@ func Create(params *plan.CreateRequestParams) chargebee.RequestObj {
 func Update(id string, params *plan.UpdateRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/plans/%v", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func List(params *plan.ListRequestParams) chargebee.RequestObj {
+func List(params *plan.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/plans"), params)
 }
 func Retrieve(id string) chargebee.RequestObj {

--- a/actions/plan/plan.go
+++ b/actions/plan/plan.go
@@ -7,24 +7,24 @@ import (
 	"net/url"
 )
 
-func Create(params *plan.CreateRequestParams) chargebee.RequestObj {
+func Create(params *plan.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/plans"), params).SetIdempotency(true)
 }
-func Update(id string, params *plan.UpdateRequestParams) chargebee.RequestObj {
+func Update(id string, params *plan.UpdateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/plans/%v", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func List(params *plan.ListRequestParams) chargebee.ListRequestObj {
+func List(params *plan.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/plans"), params)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/plans/%v", url.PathEscape(id)), nil)
 }
-func Delete(id string) chargebee.RequestObj {
+func Delete(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/plans/%v/delete", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func Copy(params *plan.CopyRequestParams) chargebee.RequestObj {
+func Copy(params *plan.CopyRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/plans/copy"), params).SetIdempotency(true)
 }
-func Unarchive(id string) chargebee.RequestObj {
+func Unarchive(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/plans/%v/unarchive", url.PathEscape(id)), nil).SetIdempotency(true)
 }

--- a/actions/portalsession/portal_session.go
+++ b/actions/portalsession/portal_session.go
@@ -7,15 +7,15 @@ import (
 	"net/url"
 )
 
-func Create(params *portalsession.CreateRequestParams) chargebee.RequestObj {
+func Create(params *portalsession.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/portal_sessions"), params).SetIdempotency(true)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/portal_sessions/%v", url.PathEscape(id)), nil)
 }
-func Logout(id string) chargebee.RequestObj {
+func Logout(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/portal_sessions/%v/logout", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func Activate(id string, params *portalsession.ActivateRequestParams) chargebee.RequestObj {
+func Activate(id string, params *portalsession.ActivateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/portal_sessions/%v/activate", url.PathEscape(id)), params).SetIdempotency(true)
 }

--- a/actions/pricevariant/price_variant.go
+++ b/actions/pricevariant/price_variant.go
@@ -7,18 +7,18 @@ import (
 	"net/url"
 )
 
-func Create(params *pricevariant.CreateRequestParams) chargebee.RequestObj {
+func Create(params *pricevariant.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/price_variants"), params).SetIdempotency(true)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/price_variants/%v", url.PathEscape(id)), nil)
 }
-func Update(id string, params *pricevariant.UpdateRequestParams) chargebee.RequestObj {
+func Update(id string, params *pricevariant.UpdateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/price_variants/%v", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Delete(id string) chargebee.RequestObj {
+func Delete(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/price_variants/%v/delete", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func List(params *pricevariant.ListRequestParams) chargebee.ListRequestObj {
+func List(params *pricevariant.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/price_variants"), params)
 }

--- a/actions/pricevariant/price_variant.go
+++ b/actions/pricevariant/price_variant.go
@@ -19,6 +19,6 @@ func Update(id string, params *pricevariant.UpdateRequestParams) chargebee.Reque
 func Delete(id string) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/price_variants/%v/delete", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func List(params *pricevariant.ListRequestParams) chargebee.RequestObj {
+func List(params *pricevariant.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/price_variants"), params)
 }

--- a/actions/pricingpagesession/pricing_page_session.go
+++ b/actions/pricingpagesession/pricing_page_session.go
@@ -6,9 +6,9 @@ import (
 	"github.com/chargebee/chargebee-go/v3/models/pricingpagesession"
 )
 
-func CreateForNewSubscription(params *pricingpagesession.CreateForNewSubscriptionRequestParams) chargebee.RequestObj {
+func CreateForNewSubscription(params *pricingpagesession.CreateForNewSubscriptionRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/pricing_page_sessions/create_for_new_subscription"), params).SetIdempotency(true)
 }
-func CreateForExistingSubscription(params *pricingpagesession.CreateForExistingSubscriptionRequestParams) chargebee.RequestObj {
+func CreateForExistingSubscription(params *pricingpagesession.CreateForExistingSubscriptionRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/pricing_page_sessions/create_for_existing_subscription"), params).SetIdempotency(true)
 }

--- a/actions/promotionalcredit/promotional_credit.go
+++ b/actions/promotionalcredit/promotional_credit.go
@@ -7,18 +7,18 @@ import (
 	"net/url"
 )
 
-func Add(params *promotionalcredit.AddRequestParams) chargebee.RequestObj {
+func Add(params *promotionalcredit.AddRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/promotional_credits/add"), params).SetIdempotency(true)
 }
-func Deduct(params *promotionalcredit.DeductRequestParams) chargebee.RequestObj {
+func Deduct(params *promotionalcredit.DeductRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/promotional_credits/deduct"), params).SetIdempotency(true)
 }
-func Set(params *promotionalcredit.SetRequestParams) chargebee.RequestObj {
+func Set(params *promotionalcredit.SetRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/promotional_credits/set"), params).SetIdempotency(true)
 }
-func List(params *promotionalcredit.ListRequestParams) chargebee.ListRequestObj {
+func List(params *promotionalcredit.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/promotional_credits"), params)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/promotional_credits/%v", url.PathEscape(id)), nil)
 }

--- a/actions/promotionalcredit/promotional_credit.go
+++ b/actions/promotionalcredit/promotional_credit.go
@@ -16,7 +16,7 @@ func Deduct(params *promotionalcredit.DeductRequestParams) chargebee.RequestObj 
 func Set(params *promotionalcredit.SetRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/promotional_credits/set"), params).SetIdempotency(true)
 }
-func List(params *promotionalcredit.ListRequestParams) chargebee.RequestObj {
+func List(params *promotionalcredit.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/promotional_credits"), params)
 }
 func Retrieve(id string) chargebee.RequestObj {

--- a/actions/purchase/purchase.go
+++ b/actions/purchase/purchase.go
@@ -6,9 +6,9 @@ import (
 	"github.com/chargebee/chargebee-go/v3/models/purchase"
 )
 
-func Create(params *purchase.CreateRequestParams) chargebee.RequestObj {
+func Create(params *purchase.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/purchases"), params).SetIdempotency(true)
 }
-func Estimate(params *purchase.EstimateRequestParams) chargebee.RequestObj {
+func Estimate(params *purchase.EstimateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/purchases/estimate"), params)
 }

--- a/actions/quote/quote.go
+++ b/actions/quote/quote.go
@@ -7,63 +7,63 @@ import (
 	"net/url"
 )
 
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/quotes/%v", url.PathEscape(id)), nil)
 }
-func CreateSubForCustomerQuote(id string, params *quote.CreateSubForCustomerQuoteRequestParams) chargebee.RequestObj {
+func CreateSubForCustomerQuote(id string, params *quote.CreateSubForCustomerQuoteRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/create_subscription_quote", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func EditCreateSubForCustomerQuote(id string, params *quote.EditCreateSubForCustomerQuoteRequestParams) chargebee.RequestObj {
+func EditCreateSubForCustomerQuote(id string, params *quote.EditCreateSubForCustomerQuoteRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/edit_create_subscription_quote", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func UpdateSubscriptionQuote(params *quote.UpdateSubscriptionQuoteRequestParams) chargebee.RequestObj {
+func UpdateSubscriptionQuote(params *quote.UpdateSubscriptionQuoteRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/quotes/update_subscription_quote"), params).SetIdempotency(true)
 }
-func EditUpdateSubscriptionQuote(id string, params *quote.EditUpdateSubscriptionQuoteRequestParams) chargebee.RequestObj {
+func EditUpdateSubscriptionQuote(id string, params *quote.EditUpdateSubscriptionQuoteRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/edit_update_subscription_quote", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func CreateForOnetimeCharges(params *quote.CreateForOnetimeChargesRequestParams) chargebee.RequestObj {
+func CreateForOnetimeCharges(params *quote.CreateForOnetimeChargesRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/quotes/create_for_onetime_charges"), params).SetIdempotency(true)
 }
-func EditOneTimeQuote(id string, params *quote.EditOneTimeQuoteRequestParams) chargebee.RequestObj {
+func EditOneTimeQuote(id string, params *quote.EditOneTimeQuoteRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/edit_one_time_quote", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func CreateSubItemsForCustomerQuote(id string, params *quote.CreateSubItemsForCustomerQuoteRequestParams) chargebee.RequestObj {
+func CreateSubItemsForCustomerQuote(id string, params *quote.CreateSubItemsForCustomerQuoteRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/create_subscription_quote_for_items", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func EditCreateSubCustomerQuoteForItems(id string, params *quote.EditCreateSubCustomerQuoteForItemsRequestParams) chargebee.RequestObj {
+func EditCreateSubCustomerQuoteForItems(id string, params *quote.EditCreateSubCustomerQuoteForItemsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/edit_create_subscription_quote_for_items", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func UpdateSubscriptionQuoteForItems(params *quote.UpdateSubscriptionQuoteForItemsRequestParams) chargebee.RequestObj {
+func UpdateSubscriptionQuoteForItems(params *quote.UpdateSubscriptionQuoteForItemsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/quotes/update_subscription_quote_for_items"), params).SetIdempotency(true)
 }
-func EditUpdateSubscriptionQuoteForItems(id string, params *quote.EditUpdateSubscriptionQuoteForItemsRequestParams) chargebee.RequestObj {
+func EditUpdateSubscriptionQuoteForItems(id string, params *quote.EditUpdateSubscriptionQuoteForItemsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/edit_update_subscription_quote_for_items", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func CreateForChargeItemsAndCharges(params *quote.CreateForChargeItemsAndChargesRequestParams) chargebee.RequestObj {
+func CreateForChargeItemsAndCharges(params *quote.CreateForChargeItemsAndChargesRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/quotes/create_for_charge_items_and_charges"), params).SetIdempotency(true)
 }
-func EditForChargeItemsAndCharges(id string, params *quote.EditForChargeItemsAndChargesRequestParams) chargebee.RequestObj {
+func EditForChargeItemsAndCharges(id string, params *quote.EditForChargeItemsAndChargesRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/edit_for_charge_items_and_charges", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func List(params *quote.ListRequestParams) chargebee.ListRequestObj {
+func List(params *quote.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/quotes"), params)
 }
-func QuoteLineGroupsForQuote(id string, params *quote.QuoteLineGroupsForQuoteRequestParams) chargebee.ListRequestObj {
+func QuoteLineGroupsForQuote(id string, params *quote.QuoteLineGroupsForQuoteRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/quotes/%v/quote_line_groups", url.PathEscape(id)), params)
 }
-func Convert(id string, params *quote.ConvertRequestParams) chargebee.RequestObj {
+func Convert(id string, params *quote.ConvertRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/convert", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func UpdateStatus(id string, params *quote.UpdateStatusRequestParams) chargebee.RequestObj {
+func UpdateStatus(id string, params *quote.UpdateStatusRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/update_status", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func ExtendExpiryDate(id string, params *quote.ExtendExpiryDateRequestParams) chargebee.RequestObj {
+func ExtendExpiryDate(id string, params *quote.ExtendExpiryDateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/extend_expiry_date", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Delete(id string, params *quote.DeleteRequestParams) chargebee.RequestObj {
+func Delete(id string, params *quote.DeleteRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/delete", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Pdf(id string, params *quote.PdfRequestParams) chargebee.RequestObj {
+func Pdf(id string, params *quote.PdfRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/pdf", url.PathEscape(id)), params).SetIdempotency(true)
 }

--- a/actions/quote/quote.go
+++ b/actions/quote/quote.go
@@ -46,10 +46,10 @@ func CreateForChargeItemsAndCharges(params *quote.CreateForChargeItemsAndCharges
 func EditForChargeItemsAndCharges(id string, params *quote.EditForChargeItemsAndChargesRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/quotes/%v/edit_for_charge_items_and_charges", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func List(params *quote.ListRequestParams) chargebee.RequestObj {
+func List(params *quote.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/quotes"), params)
 }
-func QuoteLineGroupsForQuote(id string, params *quote.QuoteLineGroupsForQuoteRequestParams) chargebee.RequestObj {
+func QuoteLineGroupsForQuote(id string, params *quote.QuoteLineGroupsForQuoteRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/quotes/%v/quote_line_groups", url.PathEscape(id)), params)
 }
 func Convert(id string, params *quote.ConvertRequestParams) chargebee.RequestObj {

--- a/actions/ramp/ramp.go
+++ b/actions/ramp/ramp.go
@@ -19,6 +19,6 @@ func Retrieve(id string) chargebee.RequestObj {
 func Delete(id string) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/ramps/%v/delete", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func List(params *ramp.ListRequestParams) chargebee.RequestObj {
+func List(params *ramp.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/ramps"), params)
 }

--- a/actions/ramp/ramp.go
+++ b/actions/ramp/ramp.go
@@ -7,18 +7,18 @@ import (
 	"net/url"
 )
 
-func CreateForSubscription(id string, params *ramp.CreateForSubscriptionRequestParams) chargebee.RequestObj {
+func CreateForSubscription(id string, params *ramp.CreateForSubscriptionRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/create_ramp", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Update(id string, params *ramp.UpdateRequestParams) chargebee.RequestObj {
+func Update(id string, params *ramp.UpdateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/ramps/%v/update", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/ramps/%v", url.PathEscape(id)), nil)
 }
-func Delete(id string) chargebee.RequestObj {
+func Delete(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/ramps/%v/delete", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func List(params *ramp.ListRequestParams) chargebee.ListRequestObj {
+func List(params *ramp.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/ramps"), params)
 }

--- a/actions/recordedpurchase/recorded_purchase.go
+++ b/actions/recordedpurchase/recorded_purchase.go
@@ -7,9 +7,9 @@ import (
 	"net/url"
 )
 
-func Create(params *recordedpurchase.CreateRequestParams) chargebee.RequestObj {
+func Create(params *recordedpurchase.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/recorded_purchases"), params).SetIdempotency(true)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/recorded_purchases/%v", url.PathEscape(id)), nil)
 }

--- a/actions/resourcemigration/resource_migration.go
+++ b/actions/resourcemigration/resource_migration.go
@@ -6,6 +6,6 @@ import (
 	"github.com/chargebee/chargebee-go/v3/models/resourcemigration"
 )
 
-func RetrieveLatest(params *resourcemigration.RetrieveLatestRequestParams) chargebee.RequestObj {
+func RetrieveLatest(params *resourcemigration.RetrieveLatestRequestParams) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/resource_migrations/retrieve_latest"), params)
 }

--- a/actions/rule/rule.go
+++ b/actions/rule/rule.go
@@ -6,6 +6,6 @@ import (
 	"net/url"
 )
 
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/rules/%v", url.PathEscape(id)), nil)
 }

--- a/actions/sitemigrationdetail/site_migration_detail.go
+++ b/actions/sitemigrationdetail/site_migration_detail.go
@@ -6,6 +6,6 @@ import (
 	"github.com/chargebee/chargebee-go/v3/models/sitemigrationdetail"
 )
 
-func List(params *sitemigrationdetail.ListRequestParams) chargebee.RequestObj {
+func List(params *sitemigrationdetail.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/site_migration_details"), params)
 }

--- a/actions/sitemigrationdetail/site_migration_detail.go
+++ b/actions/sitemigrationdetail/site_migration_detail.go
@@ -6,6 +6,6 @@ import (
 	"github.com/chargebee/chargebee-go/v3/models/sitemigrationdetail"
 )
 
-func List(params *sitemigrationdetail.ListRequestParams) chargebee.ListRequestObj {
+func List(params *sitemigrationdetail.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/site_migration_details"), params)
 }

--- a/actions/subscription/subscription.go
+++ b/actions/subscription/subscription.go
@@ -16,16 +16,16 @@ func CreateForCustomer(id string, params *subscription.CreateForCustomerRequestP
 func CreateWithItems(id string, params *subscription.CreateWithItemsRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/subscription_for_items", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func List(params *subscription.ListRequestParams) chargebee.RequestObj {
+func List(params *subscription.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/subscriptions"), params)
 }
-func SubscriptionsForCustomer(id string, params *subscription.SubscriptionsForCustomerRequestParams) chargebee.RequestObj {
+func SubscriptionsForCustomer(id string, params *subscription.SubscriptionsForCustomerRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/subscriptions", url.PathEscape(id)), params)
 }
-func ContractTermsForSubscription(id string, params *subscription.ContractTermsForSubscriptionRequestParams) chargebee.RequestObj {
+func ContractTermsForSubscription(id string, params *subscription.ContractTermsForSubscriptionRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/subscriptions/%v/contract_terms", url.PathEscape(id)), params)
 }
-func ListDiscounts(id string, params *subscription.ListDiscountsRequestParams) chargebee.RequestObj {
+func ListDiscounts(id string, params *subscription.ListDiscountsRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/subscriptions/%v/discounts", url.PathEscape(id)), params)
 }
 func Retrieve(id string) chargebee.RequestObj {

--- a/actions/subscription/subscription.go
+++ b/actions/subscription/subscription.go
@@ -7,114 +7,114 @@ import (
 	"net/url"
 )
 
-func Create(params *subscription.CreateRequestParams) chargebee.RequestObj {
+func Create(params *subscription.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions"), params).SetIdempotency(true)
 }
-func CreateForCustomer(id string, params *subscription.CreateForCustomerRequestParams) chargebee.RequestObj {
+func CreateForCustomer(id string, params *subscription.CreateForCustomerRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/subscriptions", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func CreateWithItems(id string, params *subscription.CreateWithItemsRequestParams) chargebee.RequestObj {
+func CreateWithItems(id string, params *subscription.CreateWithItemsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/subscription_for_items", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func List(params *subscription.ListRequestParams) chargebee.ListRequestObj {
+func List(params *subscription.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/subscriptions"), params)
 }
-func SubscriptionsForCustomer(id string, params *subscription.SubscriptionsForCustomerRequestParams) chargebee.ListRequestObj {
+func SubscriptionsForCustomer(id string, params *subscription.SubscriptionsForCustomerRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/subscriptions", url.PathEscape(id)), params)
 }
-func ContractTermsForSubscription(id string, params *subscription.ContractTermsForSubscriptionRequestParams) chargebee.ListRequestObj {
+func ContractTermsForSubscription(id string, params *subscription.ContractTermsForSubscriptionRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/subscriptions/%v/contract_terms", url.PathEscape(id)), params)
 }
-func ListDiscounts(id string, params *subscription.ListDiscountsRequestParams) chargebee.ListRequestObj {
+func ListDiscounts(id string, params *subscription.ListDiscountsRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/subscriptions/%v/discounts", url.PathEscape(id)), params)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/subscriptions/%v", url.PathEscape(id)), nil)
 }
-func RetrieveWithScheduledChanges(id string) chargebee.RequestObj {
+func RetrieveWithScheduledChanges(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/subscriptions/%v/retrieve_with_scheduled_changes", url.PathEscape(id)), nil)
 }
-func RemoveScheduledChanges(id string) chargebee.RequestObj {
+func RemoveScheduledChanges(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/remove_scheduled_changes", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func RemoveScheduledCancellation(id string, params *subscription.RemoveScheduledCancellationRequestParams) chargebee.RequestObj {
+func RemoveScheduledCancellation(id string, params *subscription.RemoveScheduledCancellationRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/remove_scheduled_cancellation", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func RemoveCoupons(id string, params *subscription.RemoveCouponsRequestParams) chargebee.RequestObj {
+func RemoveCoupons(id string, params *subscription.RemoveCouponsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/remove_coupons", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Update(id string, params *subscription.UpdateRequestParams) chargebee.RequestObj {
+func Update(id string, params *subscription.UpdateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func UpdateForItems(id string, params *subscription.UpdateForItemsRequestParams) chargebee.RequestObj {
+func UpdateForItems(id string, params *subscription.UpdateForItemsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/update_for_items", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func ChangeTermEnd(id string, params *subscription.ChangeTermEndRequestParams) chargebee.RequestObj {
+func ChangeTermEnd(id string, params *subscription.ChangeTermEndRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/change_term_end", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Reactivate(id string, params *subscription.ReactivateRequestParams) chargebee.RequestObj {
+func Reactivate(id string, params *subscription.ReactivateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/reactivate", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func AddChargeAtTermEnd(id string, params *subscription.AddChargeAtTermEndRequestParams) chargebee.RequestObj {
+func AddChargeAtTermEnd(id string, params *subscription.AddChargeAtTermEndRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/add_charge_at_term_end", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func ChargeAddonAtTermEnd(id string, params *subscription.ChargeAddonAtTermEndRequestParams) chargebee.RequestObj {
+func ChargeAddonAtTermEnd(id string, params *subscription.ChargeAddonAtTermEndRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/charge_addon_at_term_end", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func ChargeFutureRenewals(id string, params *subscription.ChargeFutureRenewalsRequestParams) chargebee.RequestObj {
+func ChargeFutureRenewals(id string, params *subscription.ChargeFutureRenewalsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/charge_future_renewals", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func EditAdvanceInvoiceSchedule(id string, params *subscription.EditAdvanceInvoiceScheduleRequestParams) chargebee.RequestObj {
+func EditAdvanceInvoiceSchedule(id string, params *subscription.EditAdvanceInvoiceScheduleRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/edit_advance_invoice_schedule", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func RetrieveAdvanceInvoiceSchedule(id string) chargebee.RequestObj {
+func RetrieveAdvanceInvoiceSchedule(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/subscriptions/%v/retrieve_advance_invoice_schedule", url.PathEscape(id)), nil)
 }
-func RemoveAdvanceInvoiceSchedule(id string, params *subscription.RemoveAdvanceInvoiceScheduleRequestParams) chargebee.RequestObj {
+func RemoveAdvanceInvoiceSchedule(id string, params *subscription.RemoveAdvanceInvoiceScheduleRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/remove_advance_invoice_schedule", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func RegenerateInvoice(id string, params *subscription.RegenerateInvoiceRequestParams) chargebee.RequestObj {
+func RegenerateInvoice(id string, params *subscription.RegenerateInvoiceRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/regenerate_invoice", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func ImportSubscription(params *subscription.ImportSubscriptionRequestParams) chargebee.RequestObj {
+func ImportSubscription(params *subscription.ImportSubscriptionRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/import_subscription"), params).SetIdempotency(true)
 }
-func ImportForCustomer(id string, params *subscription.ImportForCustomerRequestParams) chargebee.RequestObj {
+func ImportForCustomer(id string, params *subscription.ImportForCustomerRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/import_subscription", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func ImportContractTerm(id string, params *subscription.ImportContractTermRequestParams) chargebee.RequestObj {
+func ImportContractTerm(id string, params *subscription.ImportContractTermRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/import_contract_term", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func ImportUnbilledCharges(id string, params *subscription.ImportUnbilledChargesRequestParams) chargebee.RequestObj {
+func ImportUnbilledCharges(id string, params *subscription.ImportUnbilledChargesRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/import_unbilled_charges", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func ImportForItems(id string, params *subscription.ImportForItemsRequestParams) chargebee.RequestObj {
+func ImportForItems(id string, params *subscription.ImportForItemsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/customers/%v/import_for_items", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func OverrideBillingProfile(id string, params *subscription.OverrideBillingProfileRequestParams) chargebee.RequestObj {
+func OverrideBillingProfile(id string, params *subscription.OverrideBillingProfileRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/override_billing_profile", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Delete(id string) chargebee.RequestObj {
+func Delete(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/delete", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func Pause(id string, params *subscription.PauseRequestParams) chargebee.RequestObj {
+func Pause(id string, params *subscription.PauseRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/pause", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Cancel(id string, params *subscription.CancelRequestParams) chargebee.RequestObj {
+func Cancel(id string, params *subscription.CancelRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/cancel", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func CancelForItems(id string, params *subscription.CancelForItemsRequestParams) chargebee.RequestObj {
+func CancelForItems(id string, params *subscription.CancelForItemsRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/cancel_for_items", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Resume(id string, params *subscription.ResumeRequestParams) chargebee.RequestObj {
+func Resume(id string, params *subscription.ResumeRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/resume", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func RemoveScheduledPause(id string) chargebee.RequestObj {
+func RemoveScheduledPause(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/remove_scheduled_pause", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func RemoveScheduledResumption(id string) chargebee.RequestObj {
+func RemoveScheduledResumption(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/remove_scheduled_resumption", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func Move(id string, params *subscription.MoveRequestParams) chargebee.RequestObj {
+func Move(id string, params *subscription.MoveRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/move", url.PathEscape(id)), params).SetIdempotency(true)
 }

--- a/actions/subscriptionentitlement/subscription_entitlement.go
+++ b/actions/subscriptionentitlement/subscription_entitlement.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 )
 
-func SubscriptionEntitlementsForSubscription(id string, params *subscriptionentitlement.SubscriptionEntitlementsForSubscriptionRequestParams) chargebee.RequestObj {
+func SubscriptionEntitlementsForSubscription(id string, params *subscriptionentitlement.SubscriptionEntitlementsForSubscriptionRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/subscriptions/%v/subscription_entitlements", url.PathEscape(id)), params)
 }
 func SetSubscriptionEntitlementAvailability(id string, params *subscriptionentitlement.SetSubscriptionEntitlementAvailabilityRequestParams) chargebee.RequestObj {

--- a/actions/subscriptionentitlement/subscription_entitlement.go
+++ b/actions/subscriptionentitlement/subscription_entitlement.go
@@ -7,9 +7,9 @@ import (
 	"net/url"
 )
 
-func SubscriptionEntitlementsForSubscription(id string, params *subscriptionentitlement.SubscriptionEntitlementsForSubscriptionRequestParams) chargebee.ListRequestObj {
+func SubscriptionEntitlementsForSubscription(id string, params *subscriptionentitlement.SubscriptionEntitlementsForSubscriptionRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/subscriptions/%v/subscription_entitlements", url.PathEscape(id)), params)
 }
-func SetSubscriptionEntitlementAvailability(id string, params *subscriptionentitlement.SetSubscriptionEntitlementAvailabilityRequestParams) chargebee.RequestObj {
+func SetSubscriptionEntitlementAvailability(id string, params *subscriptionentitlement.SetSubscriptionEntitlementAvailabilityRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/subscription_entitlements/set_availability", url.PathEscape(id)), params).SetIdempotency(true)
 }

--- a/actions/timemachine/time_machine.go
+++ b/actions/timemachine/time_machine.go
@@ -11,13 +11,13 @@ import (
 	"time"
 )
 
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/time_machines/%v", url.PathEscape(id)), nil)
 }
-func StartAfresh(id string, params *timemachine.StartAfreshRequestParams) chargebee.RequestObj {
+func StartAfresh(id string, params *timemachine.StartAfreshRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/time_machines/%v/start_afresh", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func TravelForward(id string, params *timemachine.TravelForwardRequestParams) chargebee.RequestObj {
+func TravelForward(id string, params *timemachine.TravelForwardRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/time_machines/%v/travel_forward", url.PathEscape(id)), params).SetIdempotency(true)
 }
 func WaitForTimeTravelCompletion(tm timemachine.TimeMachine) (timemachine.TimeMachine, error) {

--- a/actions/transaction/transaction.go
+++ b/actions/transaction/transaction.go
@@ -22,16 +22,16 @@ func Reconcile(id string, params *transaction.ReconcileRequestParams) chargebee.
 func Refund(id string, params *transaction.RefundRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/transactions/%v/refund", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func List(params *transaction.ListRequestParams) chargebee.RequestObj {
+func List(params *transaction.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/transactions"), params)
 }
-func TransactionsForCustomer(id string, params *transaction.TransactionsForCustomerRequestParams) chargebee.RequestObj {
+func TransactionsForCustomer(id string, params *transaction.TransactionsForCustomerRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/transactions", url.PathEscape(id)), params)
 }
-func TransactionsForSubscription(id string, params *transaction.TransactionsForSubscriptionRequestParams) chargebee.RequestObj {
+func TransactionsForSubscription(id string, params *transaction.TransactionsForSubscriptionRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/subscriptions/%v/transactions", url.PathEscape(id)), params)
 }
-func PaymentsForInvoice(id string, params *transaction.PaymentsForInvoiceRequestParams) chargebee.RequestObj {
+func PaymentsForInvoice(id string, params *transaction.PaymentsForInvoiceRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/invoices/%v/payments", url.PathEscape(id)), params)
 }
 func Retrieve(id string) chargebee.RequestObj {

--- a/actions/transaction/transaction.go
+++ b/actions/transaction/transaction.go
@@ -7,36 +7,36 @@ import (
 	"net/url"
 )
 
-func CreateAuthorization(params *transaction.CreateAuthorizationRequestParams) chargebee.RequestObj {
+func CreateAuthorization(params *transaction.CreateAuthorizationRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/transactions/create_authorization"), params).SetIdempotency(true)
 }
-func VoidTransaction(id string) chargebee.RequestObj {
+func VoidTransaction(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/transactions/%v/void", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func RecordRefund(id string, params *transaction.RecordRefundRequestParams) chargebee.RequestObj {
+func RecordRefund(id string, params *transaction.RecordRefundRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/transactions/%v/record_refund", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Reconcile(id string, params *transaction.ReconcileRequestParams) chargebee.RequestObj {
+func Reconcile(id string, params *transaction.ReconcileRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/transactions/%v/reconcile", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Refund(id string, params *transaction.RefundRequestParams) chargebee.RequestObj {
+func Refund(id string, params *transaction.RefundRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/transactions/%v/refund", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func List(params *transaction.ListRequestParams) chargebee.ListRequestObj {
+func List(params *transaction.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/transactions"), params)
 }
-func TransactionsForCustomer(id string, params *transaction.TransactionsForCustomerRequestParams) chargebee.ListRequestObj {
+func TransactionsForCustomer(id string, params *transaction.TransactionsForCustomerRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/customers/%v/transactions", url.PathEscape(id)), params)
 }
-func TransactionsForSubscription(id string, params *transaction.TransactionsForSubscriptionRequestParams) chargebee.ListRequestObj {
+func TransactionsForSubscription(id string, params *transaction.TransactionsForSubscriptionRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/subscriptions/%v/transactions", url.PathEscape(id)), params)
 }
-func PaymentsForInvoice(id string, params *transaction.PaymentsForInvoiceRequestParams) chargebee.ListRequestObj {
+func PaymentsForInvoice(id string, params *transaction.PaymentsForInvoiceRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/invoices/%v/payments", url.PathEscape(id)), params)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/transactions/%v", url.PathEscape(id)), nil)
 }
-func DeleteOfflineTransaction(id string, params *transaction.DeleteOfflineTransactionRequestParams) chargebee.RequestObj {
+func DeleteOfflineTransaction(id string, params *transaction.DeleteOfflineTransactionRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/transactions/%v/delete_offline_transaction", url.PathEscape(id)), params).SetIdempotency(true)
 }

--- a/actions/unbilledcharge/unbilled_charge.go
+++ b/actions/unbilledcharge/unbilled_charge.go
@@ -19,7 +19,7 @@ func InvoiceUnbilledCharges(params *unbilledcharge.InvoiceUnbilledChargesRequest
 func Delete(id string) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/unbilled_charges/%v/delete", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func List(params *unbilledcharge.ListRequestParams) chargebee.RequestObj {
+func List(params *unbilledcharge.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/unbilled_charges"), params)
 }
 func InvoiceNowEstimate(params *unbilledcharge.InvoiceNowEstimateRequestParams) chargebee.RequestObj {

--- a/actions/unbilledcharge/unbilled_charge.go
+++ b/actions/unbilledcharge/unbilled_charge.go
@@ -7,21 +7,21 @@ import (
 	"net/url"
 )
 
-func CreateUnbilledCharge(params *unbilledcharge.CreateUnbilledChargeRequestParams) chargebee.RequestObj {
+func CreateUnbilledCharge(params *unbilledcharge.CreateUnbilledChargeRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/unbilled_charges/create"), params).SetIdempotency(true)
 }
-func Create(params *unbilledcharge.CreateRequestParams) chargebee.RequestObj {
+func Create(params *unbilledcharge.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/unbilled_charges"), params).SetIdempotency(true)
 }
-func InvoiceUnbilledCharges(params *unbilledcharge.InvoiceUnbilledChargesRequestParams) chargebee.RequestObj {
+func InvoiceUnbilledCharges(params *unbilledcharge.InvoiceUnbilledChargesRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/unbilled_charges/invoice_unbilled_charges"), params).SetIdempotency(true)
 }
-func Delete(id string) chargebee.RequestObj {
+func Delete(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/unbilled_charges/%v/delete", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func List(params *unbilledcharge.ListRequestParams) chargebee.ListRequestObj {
+func List(params *unbilledcharge.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/unbilled_charges"), params)
 }
-func InvoiceNowEstimate(params *unbilledcharge.InvoiceNowEstimateRequestParams) chargebee.RequestObj {
+func InvoiceNowEstimate(params *unbilledcharge.InvoiceNowEstimateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/unbilled_charges/invoice_now_estimate"), params)
 }

--- a/actions/usage/usage.go
+++ b/actions/usage/usage.go
@@ -7,18 +7,18 @@ import (
 	"net/url"
 )
 
-func Create(id string, params *usage.CreateRequestParams) chargebee.RequestObj {
+func Create(id string, params *usage.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/usages", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Retrieve(id string, params *usage.RetrieveRequestParams) chargebee.RequestObj {
+func Retrieve(id string, params *usage.RetrieveRequestParams) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/subscriptions/%v/usages", url.PathEscape(id)), params)
 }
-func Delete(id string, params *usage.DeleteRequestParams) chargebee.RequestObj {
+func Delete(id string, params *usage.DeleteRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/delete_usage", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func List(params *usage.ListRequestParams) chargebee.ListRequestObj {
+func List(params *usage.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/usages"), params)
 }
-func Pdf(params *usage.PdfRequestParams) chargebee.RequestObj {
+func Pdf(params *usage.PdfRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/usages/pdf"), params).SetIdempotency(true)
 }

--- a/actions/usage/usage.go
+++ b/actions/usage/usage.go
@@ -16,7 +16,7 @@ func Retrieve(id string, params *usage.RetrieveRequestParams) chargebee.RequestO
 func Delete(id string, params *usage.DeleteRequestParams) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/subscriptions/%v/delete_usage", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func List(params *usage.ListRequestParams) chargebee.RequestObj {
+func List(params *usage.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/usages"), params)
 }
 func Pdf(params *usage.PdfRequestParams) chargebee.RequestObj {

--- a/actions/usageevent/usage_event.go
+++ b/actions/usageevent/usage_event.go
@@ -6,9 +6,9 @@ import (
 	"github.com/chargebee/chargebee-go/v3/models/usageevent"
 )
 
-func Create(params *usageevent.CreateRequestParams) chargebee.RequestObj {
+func Create(params *usageevent.CreateRequestParams) chargebee.Request {
 	return chargebee.SendJsonRequest("POST", fmt.Sprintf("/usage_events"), params).SetSubDomain("ingest")
 }
-func BatchIngest(params *usageevent.BatchIngestRequestParams) chargebee.RequestObj {
+func BatchIngest(params *usageevent.BatchIngestRequestParams) chargebee.Request {
 	return chargebee.SendJsonRequest("POST", fmt.Sprintf("/batch/usage_events"), params).SetSubDomain("ingest")
 }

--- a/actions/usagefile/usage_file.go
+++ b/actions/usagefile/usage_file.go
@@ -7,9 +7,9 @@ import (
 	"net/url"
 )
 
-func UploadUrl(params *usagefile.UploadUrlRequestParams) chargebee.RequestObj {
+func UploadUrl(params *usagefile.UploadUrlRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/usage_files/upload_url"), params).SetSubDomain("file-ingest")
 }
-func ProcessingStatus(id string) chargebee.RequestObj {
+func ProcessingStatus(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/usage_files/%v/processing_status", url.PathEscape(id)), nil).SetSubDomain("file-ingest")
 }

--- a/actions/virtualbankaccount/virtual_bank_account.go
+++ b/actions/virtualbankaccount/virtual_bank_account.go
@@ -16,7 +16,7 @@ func Create(params *virtualbankaccount.CreateRequestParams) chargebee.RequestObj
 func Retrieve(id string) chargebee.RequestObj {
 	return chargebee.Send("GET", fmt.Sprintf("/virtual_bank_accounts/%v", url.PathEscape(id)), nil)
 }
-func List(params *virtualbankaccount.ListRequestParams) chargebee.RequestObj {
+func List(params *virtualbankaccount.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/virtual_bank_accounts"), params)
 }
 func Delete(id string) chargebee.RequestObj {

--- a/actions/virtualbankaccount/virtual_bank_account.go
+++ b/actions/virtualbankaccount/virtual_bank_account.go
@@ -7,21 +7,21 @@ import (
 	"net/url"
 )
 
-func CreateUsingPermanentToken(params *virtualbankaccount.CreateUsingPermanentTokenRequestParams) chargebee.RequestObj {
+func CreateUsingPermanentToken(params *virtualbankaccount.CreateUsingPermanentTokenRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/virtual_bank_accounts/create_using_permanent_token"), params).SetIdempotency(true)
 }
-func Create(params *virtualbankaccount.CreateRequestParams) chargebee.RequestObj {
+func Create(params *virtualbankaccount.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/virtual_bank_accounts"), params).SetIdempotency(true)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/virtual_bank_accounts/%v", url.PathEscape(id)), nil)
 }
-func List(params *virtualbankaccount.ListRequestParams) chargebee.ListRequestObj {
+func List(params *virtualbankaccount.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/virtual_bank_accounts"), params)
 }
-func Delete(id string) chargebee.RequestObj {
+func Delete(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/virtual_bank_accounts/%v/delete", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func DeleteLocal(id string) chargebee.RequestObj {
+func DeleteLocal(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/virtual_bank_accounts/%v/delete_local", url.PathEscape(id)), nil).SetIdempotency(true)
 }

--- a/actions/webhookendpoint/webhook_endpoint.go
+++ b/actions/webhookendpoint/webhook_endpoint.go
@@ -7,18 +7,18 @@ import (
 	"net/url"
 )
 
-func Create(params *webhookendpoint.CreateRequestParams) chargebee.RequestObj {
+func Create(params *webhookendpoint.CreateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/webhook_endpoints"), params).SetIdempotency(true)
 }
-func Update(id string, params *webhookendpoint.UpdateRequestParams) chargebee.RequestObj {
+func Update(id string, params *webhookendpoint.UpdateRequestParams) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/webhook_endpoints/%v", url.PathEscape(id)), params).SetIdempotency(true)
 }
-func Retrieve(id string) chargebee.RequestObj {
+func Retrieve(id string) chargebee.Request {
 	return chargebee.Send("GET", fmt.Sprintf("/webhook_endpoints/%v", url.PathEscape(id)), nil)
 }
-func Delete(id string) chargebee.RequestObj {
+func Delete(id string) chargebee.Request {
 	return chargebee.Send("POST", fmt.Sprintf("/webhook_endpoints/%v/delete", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func List(params *webhookendpoint.ListRequestParams) chargebee.ListRequestObj {
+func List(params *webhookendpoint.ListRequestParams) chargebee.ListRequest {
 	return chargebee.SendList("GET", fmt.Sprintf("/webhook_endpoints"), params)
 }

--- a/actions/webhookendpoint/webhook_endpoint.go
+++ b/actions/webhookendpoint/webhook_endpoint.go
@@ -19,6 +19,6 @@ func Retrieve(id string) chargebee.RequestObj {
 func Delete(id string) chargebee.RequestObj {
 	return chargebee.Send("POST", fmt.Sprintf("/webhook_endpoints/%v/delete", url.PathEscape(id)), nil).SetIdempotency(true)
 }
-func List(params *webhookendpoint.ListRequestParams) chargebee.RequestObj {
+func List(params *webhookendpoint.ListRequestParams) chargebee.ListRequestObj {
 	return chargebee.SendList("GET", fmt.Sprintf("/webhook_endpoints"), params)
 }

--- a/http_util.go
+++ b/http_util.go
@@ -41,26 +41,29 @@ type ListRequestObj struct {
 	idempotent    bool
 }
 
+type Request = RequestObj
+type ListRequest = ListRequestObj
+
 func basicAuth(key string) string {
 	return base64.StdEncoding.EncodeToString([]byte(key))
 }
 
 // Send prepares a RequestObj for Request operation.
-func Send(method string, path string, params interface{}) RequestObj {
+func Send(method string, path string, params interface{}) Request {
 	var form *url.Values
 
 	if params != nil {
 		form = SerializeParams(params)
 	}
 
-	return RequestObj{
+	return Request{
 		Params: form,
 		Method: method,
 		Path:   path,
 	}
 }
 
-func SendJsonRequest(method string, path string, params interface{}) RequestObj {
+func SendJsonRequest(method string, path string, params interface{}) Request {
 	var body string
 
 	if params != nil {
@@ -74,7 +77,7 @@ func SendJsonRequest(method string, path string, params interface{}) RequestObj 
 
 	}
 
-	return RequestObj{
+	return Request{
 		Method:        method,
 		Path:          path,
 		JsonBody:      body,
@@ -82,14 +85,14 @@ func SendJsonRequest(method string, path string, params interface{}) RequestObj 
 	}
 }
 
-// SendList prepares a ListRequestObj for ListRequest operation.
-func SendList(method string, path string, params interface{}) ListRequestObj {
+// SendList prepares a ListRequest for ListRequest operation.
+func SendList(method string, path string, params interface{}) ListRequest {
 	var form *url.Values
 	if params != nil {
 		form = SerializeListParams(params)
 	}
 
-	return ListRequestObj{
+	return ListRequest{
 		Params: form,
 		Method: method,
 		Path:   path,
@@ -98,14 +101,14 @@ func SendList(method string, path string, params interface{}) ListRequestObj {
 
 // AddParams add a new key-value pair to the RequestObj.Params.
 // This is used to add extra/custom_field params  in the request data.
-func (request RequestObj) AddParams(key string, value interface{}) RequestObj {
+func (request Request) AddParams(key string, value interface{}) Request {
 	request.Params.Set(key, fmt.Sprintf("%v", value))
 	return request
 }
 
 // Headers add a new key-value pair to the RequestObj.Header .
 // This is used to add custom headers .
-func (request RequestObj) Headers(key string, value string) RequestObj {
+func (request Request) Headers(key string, value string) Request {
 	if request.Header == nil {
 		request.Header = make(map[string]string)
 	}
@@ -114,7 +117,7 @@ func (request RequestObj) Headers(key string, value string) RequestObj {
 }
 
 // This is used to add idempotency key .
-func (request RequestObj) SetIdempotencyKey(idempotencyKey string) RequestObj {
+func (request Request) SetIdempotencyKey(idempotencyKey string) Request {
 	if request.Header == nil {
 		request.Header = make(map[string]string)
 	}
@@ -122,12 +125,12 @@ func (request RequestObj) SetIdempotencyKey(idempotencyKey string) RequestObj {
 	return request
 }
 
-func (request RequestObj) SetSubDomain(subDomain string) RequestObj {
+func (request Request) SetSubDomain(subDomain string) Request {
 	request.subDomain = subDomain
 	return request
 }
 
-func (request RequestObj) SetIdempotency(idempotent bool) RequestObj {
+func (request Request) SetIdempotency(idempotent bool) Request {
 	request.idempotent = idempotent
 	return request
 }
@@ -135,23 +138,23 @@ func (request RequestObj) SetIdempotency(idempotent bool) RequestObj {
 // Context used for request. It may carry deadlines, cancelation signals,
 // and other request-scoped values across API boundaries and between
 // processes.
-func (request RequestObj) Contexts(ctx context.Context) RequestObj {
+func (request Request) Contexts(ctx context.Context) Request {
 	request.Context = ctx
 	return request
 }
 
 // ListRequestObj methods
 
-// AddParams add a new key-value pair to the ListRequestObj.Params.
+// AddParams add a new key-value pair to the ListRequest.Params.
 // This is used to add extra/custom_field params in the request data.
-func (request ListRequestObj) AddParams(key string, value interface{}) ListRequestObj {
+func (request ListRequest) AddParams(key string, value interface{}) ListRequest {
 	request.Params.Set(key, fmt.Sprintf("%v", value))
 	return request
 }
 
-// Headers add a new key-value pair to the ListRequestObj.Header.
+// Headers add a new key-value pair to the ListRequest.Header.
 // This is used to add custom headers.
-func (request ListRequestObj) Headers(key string, value string) ListRequestObj {
+func (request ListRequest) Headers(key string, value string) ListRequest {
 	if request.Header == nil {
 		request.Header = make(map[string]string)
 	}
@@ -160,7 +163,7 @@ func (request ListRequestObj) Headers(key string, value string) ListRequestObj {
 }
 
 // SetIdempotencyKey is used to add idempotency key.
-func (request ListRequestObj) SetIdempotencyKey(idempotencyKey string) ListRequestObj {
+func (request ListRequest) SetIdempotencyKey(idempotencyKey string) ListRequest {
 	if request.Header == nil {
 		request.Header = make(map[string]string)
 	}
@@ -168,12 +171,12 @@ func (request ListRequestObj) SetIdempotencyKey(idempotencyKey string) ListReque
 	return request
 }
 
-func (request ListRequestObj) SetSubDomain(subDomain string) ListRequestObj {
+func (request ListRequest) SetSubDomain(subDomain string) ListRequest {
 	request.subDomain = subDomain
 	return request
 }
 
-func (request ListRequestObj) SetIdempotency(idempotent bool) ListRequestObj {
+func (request ListRequest) SetIdempotency(idempotent bool) ListRequest {
 	request.idempotent = idempotent
 	return request
 }
@@ -181,7 +184,7 @@ func (request ListRequestObj) SetIdempotency(idempotent bool) ListRequestObj {
 // Context used for request. It may carry deadlines, cancelation signals,
 // and other request-scoped values across API boundaries and between
 // processes.
-func (request ListRequestObj) Contexts(ctx context.Context) ListRequestObj {
+func (request ListRequest) Contexts(ctx context.Context) ListRequest {
 	request.Context = ctx
 	return request
 }

--- a/list_request.go
+++ b/list_request.go
@@ -1,10 +1,10 @@
 package chargebee
 
-func (request RequestObj) ListRequest() (*ResultList, error) {
+func (request ListRequestObj) ListRequest() (*ResultList, error) {
 	result, err := request.ListRequestWithEnv(DefaultConfig())
 	return result, err
 }
-func (request RequestObj) ListRequestWithEnv(env Environment) (*ResultList, error) {
+func (request ListRequestObj) ListRequestWithEnv(env Environment) (*ResultList, error) {
 	path, body := getBody(request.Method, request.Path, request.Params)
 	req, err := newRequest(env, request.Method, path, body, request.Header, request.subDomain, false)
 	if err != nil {

--- a/list_request.go
+++ b/list_request.go
@@ -1,10 +1,10 @@
 package chargebee
 
-func (request ListRequestObj) ListRequest() (*ResultList, error) {
+func (request ListRequest) ListRequest() (*ResultList, error) {
 	result, err := request.ListRequestWithEnv(DefaultConfig())
 	return result, err
 }
-func (request ListRequestObj) ListRequestWithEnv(env Environment) (*ResultList, error) {
+func (request ListRequest) ListRequestWithEnv(env Environment) (*ResultList, error) {
 	path, body := getBody(request.Method, request.Path, request.Params)
 	req, err := newRequest(env, request.Method, path, body, request.Header, request.subDomain, false)
 	if err != nil {

--- a/request.go
+++ b/request.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-func (request RequestObj) Request() (*Result, error) {
+func (request Request) Request() (*Result, error) {
 	result, err := request.RequestWithEnv(DefaultConfig())
 	return result, err
 }
-func (request RequestObj) RequestWithEnv(env Environment) (*Result, error) {
+func (request Request) RequestWithEnv(env Environment) (*Result, error) {
 	var body io.Reader
 	var path string
 	if request.isJsonRequest {

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package chargebee
 
-const Version string = "3.36.0"
+const Version string = "3.37.0"


### PR DESCRIPTION
Previously, both `Request` and `ListRequest` could be attached to any type of request, including non-list requests. This caused confusion, as actions like `retrieve` are not list requests but behaved similarly to them.

This PR resolves that issue by clearly separating their usage.

Video Example: 

https://github.com/user-attachments/assets/2c1a3bd3-a75a-4135-b6ef-261ea21b49b6



 