### PR TITLE
 retry behaviour on RequestWithEnv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### v3.38.1 (2025-09-25)
+
+#### Bug fixes:
+* Fixed retry behavior to respect configuration passed via .RequestWithEnv(per-request-config).
+
 ### v3.38.0 (2025-09-24)
 ***
 

--- a/environment.go
+++ b/environment.go
@@ -23,6 +23,8 @@ type Environment struct {
 	EnableDebugLogs bool
 }
 
+type cbCtxKey string
+
 var (
 	TotalHTTPTimeout      = 80 * time.Second
 	ExportWaitInSecs      = 3 * time.Second
@@ -35,6 +37,8 @@ const (
 	APIVersion = "v2"
 	Charset    = "UTF-8"
 )
+
+const cbEnvKey cbCtxKey = "cb_env"
 
 func Configure(key string, siteName string) {
 	if key == "" || siteName == "" {

--- a/environment.go
+++ b/environment.go
@@ -1,6 +1,7 @@
 package chargebee
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -39,6 +40,10 @@ const (
 )
 
 const cbEnvKey cbCtxKey = "cb_env"
+
+func WithEnvironment(ctx context.Context, env Environment) context.Context {
+	return context.WithValue(ctx, cbEnvKey, env)
+}
 
 func Configure(key string, siteName string) {
 	if key == "" || siteName == "" {

--- a/http_request.go
+++ b/http_request.go
@@ -22,7 +22,7 @@ func Do(req *http.Request, isIdempotent bool) (*CBResponse, error) {
 
 	env := DefaultEnv
 	if req.Context() != nil {
-		if v := req.Context().Value("cb_env"); v != nil {
+		if v := req.Context().Value(cbEnvKey); v != nil {
 			if e, ok := v.(Environment); ok {
 				env = e
 			}

--- a/list_request.go
+++ b/list_request.go
@@ -1,5 +1,7 @@
 package chargebee
 
+import "context"
+
 func (request ListRequest) ListRequest() (*ResultList, error) {
 	result, err := request.ListRequestWithEnv(DefaultConfig())
 	return result, err
@@ -11,9 +13,11 @@ func (request ListRequest) ListRequestWithEnv(env Environment) (*ResultList, err
 		panic(err)
 	}
 	if request.Context != nil {
-		req = req.WithContext(request.Context)
+		req = req.WithContext(context.WithValue(request.Context, cbEnvKey, env))
+	} else {
+		req = req.WithContext(context.WithValue(req.Context(), cbEnvKey, env))
 	}
-	res, requestError := Do(req, request.isJsonRequest)
+	res, requestError := Do(req, request.idempotent)
 	result := &ResultList{}
 
 	if requestError != nil {

--- a/request.go
+++ b/request.go
@@ -2,6 +2,7 @@ package chargebee
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -25,7 +26,9 @@ func (request Request) RequestWithEnv(env Environment) (*Result, error) {
 		panic(err)
 	}
 	if request.Context != nil {
-		req = req.WithContext(request.Context)
+		req = req.WithContext(context.WithValue(request.Context, cbEnvKey, env))
+	} else {
+		req = req.WithContext(context.WithValue(req.Context(), cbEnvKey, env))
 	}
 	res, requestError := Do(req, request.idempotent)
 	result := &Result{}

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package chargebee
 
-const Version string = "3.38.0"
+const Version string = "3.38.1"


### PR DESCRIPTION
Bug Fix:

Fixed retry behavior to respect configuration passed via `.RequestWithEnv(per-request-config).`

