### PR TITLE
Releasing v3.38.2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### v3.38.2 (2025-10-17)
+
+#### Bug fixes:
+* Fixed an issue in request.go where JSON parse errors were ignored instead of returned.
+
 ### v3.38.1 (2025-09-25)
 
 #### Bug fixes:

--- a/request.go
+++ b/request.go
@@ -37,7 +37,7 @@ func (request Request) RequestWithEnv(env Environment) (*Result, error) {
 	}
 
 	if err := UnmarshalJSON(res.Body, result); err != nil && res.StatusCode != http.StatusNoContent {
-		return result, nil
+		return result, err
 	}
 	result.responseHeaders = res.Headers
 	result.httpStatusCode = res.StatusCode

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package chargebee
 
-const Version string = "3.38.1"
+const Version string = "3.38.2"


### PR DESCRIPTION
### v3.38.2 (2025-10-17)

#### Bug fixes:
* Fixed an issue in request.go where JSON parse errors were ignored instead of returned.